### PR TITLE
Signal Decorrelation

### DIFF
--- a/bin/exspec
+++ b/bin/exspec
@@ -24,6 +24,7 @@ parser.add_option("-w", "--wavelength", type="string",  help="wavemin,wavemax,dw
 parser.add_option("-b", "--bundlesize", type="int",  help="num spectra per bundle", default=20)
 parser.add_option("-s", "--specrange", type="string",  help="specmin,specmax (python style)", default="0,10")
 parser.add_option("-r", "--regularize", type="float",  help="regularization amount (%default)", default=0.0)
+parser.add_option("-d", "--decorrelate", dest='decorr', action='store_true', help="use resolution matrix which decorrelates signal between fibers", default=False)
 parser.add_option("--nwavestep", type=int,  help="number of wavelength steps in core extraction region", default=50)
 ### parser.add_option("-x", "--xxx",   help="some flag", action="store_true")
 
@@ -119,7 +120,7 @@ for speclo in range(specmin, specmax, opts.bundlesize):
         #- Do the extraction
         specflux, specivar, R = \
             ex2d(subimg, subivar, psf, specrange=specrange, wavelengths=ww,
-                xyrange=xyrange, regularize=opts.regularize)
+                xyrange=xyrange, regularize=opts.regularize, decorrelate=opts.decorr)
 
         #- Fill in the final output arrays
         iispec = slice(speclo-specmin, spechi-specmin)

--- a/bin/exspec
+++ b/bin/exspec
@@ -24,7 +24,7 @@ parser.add_option("-w", "--wavelength", type="string",  help="wavemin,wavemax,dw
 parser.add_option("-b", "--bundlesize", type="int",  help="num spectra per bundle", default=20)
 parser.add_option("-s", "--specrange", type="string",  help="specmin,specmax (python style)", default="0,10")
 parser.add_option("-r", "--regularize", type="float",  help="regularization amount (%default)", default=0.0)
-parser.add_option("-d", "--decorrelate", dest='decorr', action='store_true', help="use resolution matrix which decorrelates signal between fibers", default=False)
+parser.add_option("-d", "--noise_decorr", dest='ndecorr', action='store_true', help="decorrelate noise between fibers, at the cost of signal correlations between fibers", default=False)
 parser.add_option("--nwavestep", type=int,  help="number of wavelength steps in core extraction region", default=50)
 ### parser.add_option("-x", "--xxx",   help="some flag", action="store_true")
 
@@ -120,7 +120,7 @@ for speclo in range(specmin, specmax, opts.bundlesize):
         #- Do the extraction
         specflux, specivar, R = \
             ex2d(subimg, subivar, psf, specrange=specrange, wavelengths=ww,
-                xyrange=xyrange, regularize=opts.regularize, decorrelate=opts.decorr)
+                xyrange=xyrange, regularize=opts.regularize, ndecorr=opts.ndecorr)
 
         #- Fill in the final output arrays
         iispec = slice(speclo-specmin, spechi-specmin)

--- a/py/specter/extract/ex2d.py
+++ b/py/specter/extract/ex2d.py
@@ -11,7 +11,7 @@ from scipy.sparse.linalg import spsolve
 
 
 def ex2d(image, ivar, psf, specrange, wavelengths, xyrange=None,
-         full_output=False, regularize=0.0, decorrelate=False):
+         full_output=False, regularize=0.0, ndecorr=False):
     """
     2D PSF extraction of flux from image given pixel inverse variance.
     
@@ -27,7 +27,8 @@ def ex2d(image, ivar, psf, specrange, wavelengths, xyrange=None,
             cutout of this region from the full image
         full_output : if True, return a dictionary of outputs including
             intermediate outputs such as the projection matrix.
-
+        ndecorr : if True, decorrelate the noise between fibers, at the
+            cost of residual signal correlations between fibers.
         
     Returns (flux, ivar, R):
         flux[nspec, nwave] = extracted resolution convolved flux
@@ -105,10 +106,10 @@ def ex2d(image, ivar, psf, specrange, wavelengths, xyrange=None,
 
     #- Solve for Resolution matrix
     try:
-        if decorrelate:
-            R, fluxivar = resolution_from_icov(iCov, decorr=[nwave for x in range(nspec)])
-        else:
+        if ndecorr:
             R, fluxivar = resolution_from_icov(iCov)
+        else:
+            R, fluxivar = resolution_from_icov(iCov, decorr=[nwave for x in range(nspec)])
     except np.linalg.linalg.LinAlgError, err:
         outfile = 'LinAlgError_{}-{}_{}-{}.fits'.format(specrange[0], specrange[1], waverange[0], waverange[1])
         print "ERROR: Linear Algebra didn't converge"
@@ -217,7 +218,7 @@ def resolution_from_icov(icov, decorr=None):
                       covariance.
         decorr (list): produce a resolution matrix which decorrelates
                       signal between fibers, at the cost of correlated
-                      noise between fibers (False).  This list should
+                      noise between fibers (default).  This list should
                       contain the number of elements in each spectrum,
                       which is used to define the size of the blocks.
 

--- a/py/specter/extract/ex2d.py
+++ b/py/specter/extract/ex2d.py
@@ -9,8 +9,9 @@ import scipy.linalg
 from scipy.sparse import spdiags, issparse
 from scipy.sparse.linalg import spsolve
 
+
 def ex2d(image, ivar, psf, specrange, wavelengths, xyrange=None,
-         full_output=False, regularize=0.0):
+         full_output=False, regularize=0.0, decorrelate=False):
     """
     2D PSF extraction of flux from image given pixel inverse variance.
     
@@ -26,6 +27,7 @@ def ex2d(image, ivar, psf, specrange, wavelengths, xyrange=None,
             cutout of this region from the full image
         full_output : if True, return a dictionary of outputs including
             intermediate outputs such as the projection matrix.
+
         
     Returns (flux, ivar, R):
         flux[nspec, nwave] = extracted resolution convolved flux
@@ -103,7 +105,10 @@ def ex2d(image, ivar, psf, specrange, wavelengths, xyrange=None,
 
     #- Solve for Resolution matrix
     try:
-        R, fluxivar = resolution_from_icov(iCov)
+        if decorrelate:
+            R, fluxivar = resolution_from_icov(iCov, decorr=[nwave for x in range(nspec)])
+        else:
+            R, fluxivar = resolution_from_icov(iCov)
     except np.linalg.linalg.LinAlgError, err:
         outfile = 'LinAlgError_{}-{}_{}-{}.fits'.format(specrange[0], specrange[1], waverange[0], waverange[1])
         print "ERROR: Linear Algebra didn't converge"
@@ -127,54 +132,98 @@ def ex2d(image, ivar, psf, specrange, wavelengths, xyrange=None,
         return results
     else:
         return rflux, fluxivar, R
-    
 
-def sym_sqrt(a):
+
+def eigen_compose(w, v, invert=False, sqr=False):
     """
-    NAME: sym_sqrt
+    Create a matrix from its eigenvectors and eigenvalues.
 
-    PURPOSE: take 'square root' of a symmetric matrix via diagonalization
+    Given the eigendecomposition of a matrix, recompose this
+    into a real symmetric matrix.  Optionally take the square
+    root of the eigenvalues and / or invert the eigenvalues.
+    The eigenvalues are regularized such that the condition 
+    number remains within machine precision for 64bit floating 
+    point values.
 
-    USAGE: s = sym_sqrt(a)
+    Args:
+        w (array): 1D array of eigenvalues
+        v (array): 2D array of eigenvectors.
+        invert (bool): Should the eigenvalues be inverted? (False)
+        sqr (bool): Should the square root eigenvalues be used? (False)
 
-    ARGUMENT: a: real symmetric square 2D ndarray
-
-    RETURNS: s such that a = numpy.dot(s, s)
-
-    WRITTEN: Adam S. Bolton, U. of Utah, 2009
+    Returns:
+        A 2D numpy array which is the recomposed matrix.
     """
-    ### w, v = np.linalg.eigh(a)  #- np.linalg.eigh is single precision !?!
-    w, v = scipy.linalg.eigh(a)
-    
-    #- Trim meaningless eigenvalues below machine precision
-    ibad = w < w.max()*sys.float_info.epsilon
-    w[ibad] = 0.0
-        
-    # dm = n.diagflat(n.sqrt(w))
-    # result = np.dot(v, np.dot(dm, np.transpose(v)))
+    dim = w.shape[0]
 
-    #- A bit faster with sparse matrix for multiplication:
-    nw = len(w)
-    dm = spdiags(np.sqrt(w), 0, nw, nw)
-    result = v.dot( dm.dot(v.T) )
-    
-    return result
+    # Threshold is 10 times the machine precision (~1e-15)
+    threshold = 10.0 * sys.float_info.epsilon
 
-def resolution_from_icov(icov):
+    maxval = np.max(w)
+    wscaled = np.zeros_like(w)
+
+    if invert:
+        # Normally, one should avoid explicit loops in python.
+        # in this case however, we need to conditionally invert
+        # the eigenvalues only if they are above the threshold.
+        # Otherwise we might divide by zero.  Since the number
+        # of eigenvalues is never too large, this should be fine.
+        # If it does impact performance, we can improve this in
+        # the future.  NOTE: simple timing with an average over
+        # 10 loops shows that all four permutations of invert and
+        # sqr options take about the same time- so this is not
+        # an issue.
+        if sqr:
+            minval = np.sqrt(maxval) * threshold
+            replace = 1.0 / minval
+            tempsqr = np.sqrt(w)
+            for i in range(dim):
+                if tempsqr[i] > minval:
+                    wscaled[i] = 1.0 / tempsqr[i]
+                else:
+                    wscaled[i] = replace
+        else:
+            minval = maxval * threshold
+            replace = 1.0 / minval
+            for i in range(dim):
+                if w[i] > minval:
+                    wscaled[i] = 1.0 / w[i]
+                else:
+                    wscaled[i] = replace
+    else:
+        if sqr:
+            minval = np.sqrt(maxval) * threshold
+            replace = minval
+            wscaled[:] = np.where((w > minval), np.sqrt(w), replace*np.ones_like(w))
+        else:
+            minval = maxval * threshold
+            replace = minval
+            wscaled[:] = np.where((w > minval), w, replace*np.ones_like(w))
+
+    # multiply to get result
+    wdiag = spdiags(wscaled, 0, dim, dim)
+    return v.dot( wdiag.dot(v.T) )
+
+
+def resolution_from_icov(icov, decorr=None):
     """
     Function to generate the 'resolution matrix' in the simplest
     (no unrelated crosstalk) Bolton & Schlegel 2010 sense.
     Works on dense matrices.  May not be suited for production-scale
     determination in a spectro extraction pipeline.
 
-    Input argument is inverse covariance matrix array.
-    If input is not 2D and symmetric, results will be unpredictable.
-    
-    returns (R, ivar):
+    Args:
+        icov (array): real, symmetric, 2D array containing inverse
+                      covariance.
+        decorr (list): produce a resolution matrix which decorrelates
+                      signal between fibers, at the cost of correlated
+                      noise between fibers (False).  This list should
+                      contain the number of elements in each spectrum,
+                      which is used to define the size of the blocks.
+
+    Returns (R, ivar):
         R : resolution matrix
         ivar : R C R.T  -- decorrelated resolution convolved inverse variance
-
-    WRITTEN: Adam S. Bolton, U. of Utah, 2009
     """
     #- force symmetry since due to rounding it might not be exactly symmetric
     icov = 0.5*(icov + icov.T)
@@ -182,7 +231,23 @@ def resolution_from_icov(icov):
     if issparse(icov):
         icov = icov.toarray()
 
-    sqrt_icov = sym_sqrt(icov)
+    w, v = scipy.linalg.eigh(icov)
+
+    sqrt_icov = np.zeros_like(icov)
+
+    if decorr is not None:
+        if np.sum(decorr) != icov.shape[0]:
+            raise RuntimeError("The list of spectral block sizes must sum to the matrix size")
+        inverse = eigen_compose(w, v, invert=True)
+        # take each spectrum block and process
+        offset = 0
+        for b in decorr:
+            bw, bv = scipy.linalg.eigh(inverse[offset:offset+b,offset:offset+b])
+            sqrt_icov[offset:offset+b,offset:offset+b] = eigen_compose(bw, bv, invert=True, sqr=True)
+            offset += b
+    else:
+        sqrt_icov = eigen_compose(w, v, sqr=True)
+
     norm_vector = np.sum(sqrt_icov, axis=1)
     R = np.outer(norm_vector**(-1), np.ones(norm_vector.size)) * sqrt_icov
     ivar = norm_vector**2  #- Bolton & Schlegel 2010 Eqn 13

--- a/py/specter/test/test_extract.py
+++ b/py/specter/test/test_extract.py
@@ -90,7 +90,7 @@ class TestExtract(unittest.TestCase):
     def test_noiseless_ex2d(self):
         specrange = (0, self.nspec)
         ivar = np.ones(self.ivar.shape)
-        d = ex2d(self.image_orig, ivar, self.psf, specrange, self.ww, full_output=True)
+        d = ex2d(self.image_orig, ivar, self.psf, specrange, self.ww, full_output=True, ndecorr=True)
 
         R = d['R']
         flux = d['flux']     #- resolution convolved extracted flux
@@ -110,10 +110,10 @@ class TestExtract(unittest.TestCase):
         self.assertTrue( np.max(np.abs(dximg)) < 1e-6 )
 
 
-    def test_noiseless_ex2d_decorr(self):
+    def test_noiseless_ex2d_sigdecorr(self):
         specrange = (0, self.nspec)
         ivar = np.ones(self.ivar.shape)
-        d = ex2d(self.image_orig, ivar, self.psf, specrange, self.ww, full_output=True, decorrelate=True)
+        d = ex2d(self.image_orig, ivar, self.psf, specrange, self.ww, full_output=True)
 
         R = d['R']
         flux = d['flux']     #- resolution convolved extracted flux

--- a/py/specter/test/test_extract.py
+++ b/py/specter/test/test_extract.py
@@ -1,21 +1,22 @@
 #!/usr/bin/env python
 
 """
-Unit tests for PSF classes.
+Unit tests for extraction.
 """
 
 import sys
 import os
 import numpy as np
+import scipy.linalg
 import unittest
 from specter.test import test_data_dir
 from specter.psf import load_psf
-from specter.extract.ex2d import ex2d
+from specter.extract.ex2d import ex2d, eigen_compose
 
 
 class TestExtract(unittest.TestCase):
     """
-    Test functions within specter.util
+    Test functions within specter.extract
     """
     def setUp(self):
         np.random.seed(0)
@@ -39,6 +40,14 @@ class TestExtract(unittest.TestCase):
         self.psf = psf        
         self.ww = ww
         self.nspec = nspec
+
+        # construct a symmetric test matrix
+        self.dim = 100
+        self.a1 = np.random.uniform(low=0.01, high=100.0, size=(self.dim, self.dim))
+        self.a2 = np.random.uniform(low=0.01, high=100.0, size=(self.dim, self.dim))
+        self.sym = np.dot(np.transpose(self.a1), self.a1)
+        self.sym += np.dot(np.transpose(self.a2), self.a2)
+
                 
     def _test_blat(self):
         from time import time
@@ -62,6 +71,22 @@ class TestExtract(unittest.TestCase):
         
             print i, np.std(chi), np.std(pixchi)
     
+
+    def test_eigen_compose(self):
+        w, v = scipy.linalg.eigh(self.sym)
+        check = eigen_compose(w, v)
+        np.testing.assert_almost_equal(check, self.sym, decimal=5)
+        check = eigen_compose(w, v, sqr=True)
+        check = eigen_compose(w, v, invert=True)
+        check = eigen_compose(w, v, invert=True, sqr=True)
+
+        # check reconstruction
+        w_inv, v_inv = scipy.linalg.eigh(check)
+        comp_w = np.multiply(w_inv, w_inv)
+        comp = eigen_compose(comp_w, v_inv, invert=True)
+        np.testing.assert_almost_equal(comp, self.sym, decimal=3)
+
+
     def test_noiseless_ex2d(self):
         specrange = (0, self.nspec)
         ivar = np.ones(self.ivar.shape)
@@ -82,7 +107,31 @@ class TestExtract(unittest.TestCase):
         dximg = ximg - self.image_orig
 
         self.assertTrue( np.max(np.abs(bias)) < 1e-9 )
-        self.assertTrue( np.max(np.abs(dximg)) < 1e-6 )                
+        self.assertTrue( np.max(np.abs(dximg)) < 1e-6 )
+
+
+    def test_noiseless_ex2d_decorr(self):
+        specrange = (0, self.nspec)
+        ivar = np.ones(self.ivar.shape)
+        d = ex2d(self.image_orig, ivar, self.psf, specrange, self.ww, full_output=True, decorrelate=True)
+
+        R = d['R']
+        flux = d['flux']     #- resolution convolved extracted flux
+        xflux = d['xflux']   #- original extracted flux
+        
+        #- Resolution convolved input photons (flux)
+        rphot = R.dot(self.phot.ravel()).reshape(flux.shape)
+        
+        #- extracted flux projected back to image
+        ximg = self.psf.project(self.ww, xflux, verbose=False)
+        
+        #- Compare inputs to outputs
+        bias = (flux - rphot)/rphot
+        dximg = ximg - self.image_orig
+
+        self.assertTrue( np.max(np.abs(bias)) < 1e-9 )
+        self.assertTrue( np.max(np.abs(dximg)) < 1e-6 )
+
 
     #- Pull values are wrong.  Why?  Overfitting?
     @unittest.expectedFailure
@@ -114,7 +163,8 @@ class TestExtract(unittest.TestCase):
                         msg="pull_flux sigma is %f" % np.std(pull_flux))
         self.assertTrue(np.abs(1-np.std(pull_image)) < 0.05,
                         msg="pull_image sigma is %f" % np.std(pull_image))
-        
+
+
     def test_ex2d_subimage(self):
         specrange = (0, self.nspec)
         waverange = self.ww[0], self.ww[-1]
@@ -138,6 +188,7 @@ class TestExtract(unittest.TestCase):
         self.assertTrue( np.all(subflux == flux) )
         self.assertTrue( np.all(subfluxivar == fluxivar) )
         self.assertTrue( np.all(subR == R) )
+
 
     def test_wave_off_image(self):
         ww = self.psf.wmin - 5 + np.arange(10)


### PR DESCRIPTION
This changes the default behavior of specter extraction to use a slightly different resolution matrix, which by construction decorrelates signal between fibers, at the cost of small residual noise covariance between fibers (See equation 19 of Bolton & Schlegel):
![signal_decorr_project](https://cloud.githubusercontent.com/assets/84221/11135432/c394de90-8959-11e5-8842-1ff960d4cf94.png)
![signal_decorr_compare](https://cloud.githubusercontent.com/assets/84221/11135434/c7beb928-8959-11e5-9311-93f17f1ae864.png)
Closes #18