### PR TITLE
Less scipy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,10 +40,10 @@ env:
         # to repeat them for all configurations.
         - NUMPY_VERSION=1.9
         - SCIPY_VERSION=0.14
-        - ASTROPY_VERSION=1.0.4
+        - ASTROPY_VERSION=1.1
         - SPHINX_VERSION=1.3
         - FITSIO_VERSION=0.9.7
-        - DESIUTIL_VERSION=1.0.1
+        - DESIUTIL_VERSION=1.3.2
         - CONDA_INSTALL='conda install -c astropy-ci-extras --yes'
         - PIP_INSTALL='pip install'
         - OPTIONAL_DEPS=false

--- a/.travis.yml
+++ b/.travis.yml
@@ -105,11 +105,11 @@ matrix:
 
 install:
     - source etc/travis_env_$TRAVIS_OS_NAME.sh
+    - if [[ $SETUP_CMD == 'build_sphinx' ]]; then pip install Sphinx; fi
 
 script:
     - $MAIN_CMD $SETUP_CMD
 
 after_success:
     - if [[ $SETUP_CMD == 'test --coverage' ]]; then coveralls; fi
-    - if [[ $SETUP_CMD == 'build_sphinx' ]]; then pip install Sphinx; fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -111,3 +111,5 @@ script:
 
 after_success:
     - if [[ $SETUP_CMD == 'test --coverage' ]]; then coveralls; fi
+    - if [[ $SETUP_CMD == 'build_sphinx' ]]; then pip install Sphinx; fi
+

--- a/py/specter/extract/ex2d.py
+++ b/py/specter/extract/ex2d.py
@@ -19,7 +19,8 @@ def ex2d(image, ivar, psf, specrange, wavelengths, xyrange=None,
         image : 2D array of pixels
         ivar  : 2D array of inverse variance for the image
         psf   : PSF object
-        specrange : (specmin, specmax) inclusive to extract
+        specrange : (start, stop) to extract
+            (python style indexing; stop not included)
         wavelengths : 1D array of wavelengths to extract
         
     Optional Inputs:

--- a/py/specter/psf/pixpsf.py
+++ b/py/specter/psf/pixpsf.py
@@ -7,7 +7,6 @@ David Schlegel & Stephen Bailey, Summer 2011
 """
 
 import numpy as np
-import scipy.signal
 from astropy.io import fits
 from specter.psf import PSF
 from specter.util import sincshift

--- a/py/specter/psf/psf.py
+++ b/py/specter/psf/psf.py
@@ -16,6 +16,7 @@ import sys
 import numpy as np
 from numpy.polynomial.legendre import Legendre, legval, legfit
 import scipy.optimize
+import scipy.sparse
 
 from specter.util import gausspix, TraceSet, CacheDict
 from astropy.io import fits

--- a/py/specter/psf/psf.py
+++ b/py/specter/psf/psf.py
@@ -14,8 +14,6 @@ Stephen Bailey, Fall 2012
 
 import sys
 import numpy as np
-### import scipy.sparse
-from scipy.ndimage import center_of_mass
 from numpy.polynomial.legendre import Legendre, legval, legfit
 import scipy.optimize
 
@@ -515,6 +513,8 @@ class PSF(object):
             specmin : starting spectrum number
             xyrange : (xmin, xmax, ymin, ymax) range of CCD pixels
         """
+        wavelength = np.asarray(wavelength)
+        phot = np.asarray(phot)
         if specmin >= self.nspec:
             raise ValueError('specmin {} >= psf.nspec {}'.format(specmin, self.nspec))
         if specmin+phot.shape[0] > self.nspec:

--- a/py/specter/psf/spotgrid.py
+++ b/py/specter/psf/spotgrid.py
@@ -12,8 +12,6 @@ import numpy as np
 from astropy.io import fits
 from specter.psf import PSF
 from specter.util import LinearInterp2D, rebin_image, sincshift
-import scipy.interpolate
-
 
 class SpotGridPSF(PSF):
     """

--- a/py/specter/throughput.py
+++ b/py/specter/throughput.py
@@ -16,7 +16,6 @@ import os
 import warnings
 import numpy as np
 from astropy.io import fits
-import scipy.linalg
 from specter import util
 
 #- ObjType enum


### PR DESCRIPTION
Related to #28, this PR removes some extraneous scipy imports, in particular allowing you to load and use throughput without scipy.  PSFs still require scipy.

Perhaps more importantly, it fixes the travis builds by using desiutil 1.3.2 (someday I'll deprecate that dependency for specter, but haven't yet...) and installing Sphinx.

Please review and merge this to fix master (for which travis builds are also broken), even if you have more scipy-related requests to come.