### PR TITLE
python3 updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -71,10 +71,16 @@ matrix:
           env: PYTHON_VERSION=2.7 SETUP_CMD='build_sphinx'
           # -w is an astropy extension
 
-        # Try all python versions with the latest numpy
+        # Try 2.7 and 3.5 python versions with the latest numpy
         - os: linux
           env: PYTHON_VERSION=2.7 MAIN_CMD='coverage'
                SETUP_CMD="run py/specter/test/specter_test_suite.py"
+               CONDA_DEPENDENCIES=$CONDA_ALL_DEPENDENCIES
+               PIP_DEPENDENCIES=$PIP_ALL_DEPENDENCIES
+
+        - os: linux
+          env: PYTHON_VERSION=3.5 MAIN_CMD='python'
+               SETUP_CMD="py/specter/test/specter_test_suite.py"
                CONDA_DEPENDENCIES=$CONDA_ALL_DEPENDENCIES
                PIP_DEPENDENCIES=$PIP_ALL_DEPENDENCIES
 
@@ -107,8 +113,6 @@ matrix:
 install:
     - git clone git://github.com/astropy/ci-helpers.git
     - source ci-helpers/travis/setup_conda_$TRAVIS_OS_NAME.sh
-    # egg_info causes the astropy/ci-helpers script to exit before the pip
-    # packages are installed, thus desiutil is not installed in that script.
 
 script:
     - $MAIN_CMD $SETUP_CMD

--- a/bin/exspec
+++ b/bin/exspec
@@ -4,7 +4,7 @@
 Vanilla spectral extraction
 """
 
-from __future__ import absolute_import, division, print_function
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import sys
 import os

--- a/bin/exspec
+++ b/bin/exspec
@@ -4,6 +4,8 @@
 Vanilla spectral extraction
 """
 
+from __future__ import absolute_import, division, print_function
+
 import sys
 import os
 import os.path
@@ -33,7 +35,7 @@ parser.add_option("--nwavestep", type=int,  help="number of wavelength steps in 
 opts, args = parser.parse_args()
 
 #- Get wavelength grid from options
-wstart, wstop, dw = map(float, opts.wavelength.split(','))
+wstart, wstop, dw = [float(x) for x in opts.wavelength.split(',')]
 wavelengths = np.arange(wstart, wstop+dw/2.0, dw)
 nwave = len(wavelengths)
 
@@ -45,15 +47,15 @@ psf = load_psf(opts.psf)
 img, imgivar, imghdr = io.read_image(opts.input)
 
 #- Confirm that this PSF covers these wavelengths for these spectra
-psf_wavemin = np.max(psf.wavelength(range(specmin, specmax), y=0))
-psf_wavemax = np.min(psf.wavelength(range(specmin, specmax), y=psf.npix_y-1))
+psf_wavemin = np.max(psf.wavelength(list(range(specmin, specmax)), y=0))
+psf_wavemax = np.min(psf.wavelength(list(range(specmin, specmax)), y=psf.npix_y-1))
 if psf_wavemin > wstart:
-    raise ValueError, 'Start wavelength {:.2f} < min wavelength {:.2f} for these fibers'.format(wstart, psf_wavemin)
+    raise ValueError('Start wavelength {:.2f} < min wavelength {:.2f} for these fibers'.format(wstart, psf_wavemin))
 if psf_wavemax < wstop:
-    raise ValueError, 'Stop wavelength {:.2f} > max wavelength {:.2f} for these fibers'.format(wstop, psf_wavemax)
+    raise ValueError('Stop wavelength {:.2f} > max wavelength {:.2f} for these fibers'.format(wstop, psf_wavemax))
 
 #- Print parameters
-print """\
+print("""\
 #--- Extraction Parameters ---
 input:      {input}
 psf:        {psf}
@@ -67,7 +69,7 @@ regularize: {regularize}
 """.format(input=opts.input, psf=opts.psf, output=opts.output,
     wstart=wstart, wstop=wstop, dw=dw,
     specmin=opts.specmin, nspec=opts.nspec, bundlesize=opts.bundlesize,
-    regularize=opts.regularize)
+    regularize=opts.regularize))
 
 #- The actual extraction
 flux, ivar, Rd = ex2d(img, imgivar, psf, opts.specmin, opts.nspec, wavelengths,

--- a/bin/merge_bundles
+++ b/bin/merge_bundles
@@ -11,7 +11,7 @@ Stephen Bailey, LBL
 March 2014
 """
 
-from __future__ import absolute_import, division, print_function
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import sys
 import os

--- a/bin/merge_bundles
+++ b/bin/merge_bundles
@@ -11,6 +11,8 @@ Stephen Bailey, LBL
 March 2014
 """
 
+from __future__ import absolute_import, division, print_function
+
 import sys
 import os
 import numpy as np
@@ -34,7 +36,7 @@ for filename in args:
     specset.update( set(range(xhdr['SPECMIN'], xhdr['SPECMAX']+1)) )
 
 if len(specset) != nspec:
-    print "Input files only have {} instead of {} spectra".format(len(specset), nspec)
+    print("Input files only have {} instead of {} spectra".format(len(specset), nspec))
     sys.exit(1)
 
 #- Read a file to get basic dimensions
@@ -63,13 +65,13 @@ for filename in args:
     
     lo = xhdr['SPECMIN']
     hi = xhdr['SPECMAX']+1
-    ### print filename, lo, hi
+    ### print(filename, lo, hi)
     flux[lo:hi] = xflux
     ivar[lo:hi] = xivar
     R[lo:hi] = xR
     
 #- Write it out
-print "Writing", opts.output
+print("Writing", opts.output)
 io.write_spectra(opts.output, w, flux, ivar, R, hdr)
 
 #- Scary!  Delete input files

--- a/bin/specter
+++ b/bin/specter
@@ -396,9 +396,10 @@ if opts.extra:
 
     #- Spectra in photon units
     a = np.array(list(zip(photons, wavelength)),
-                dtype=[('PHOTONS',     str(photons.dtype), (nwave,)),
-                       ('WAVELENGTH',  str(wavelength.dtype), (nwave,)),
-                       ])
+            dtype=[('PHOTONS',     str(photons.dtype), (nwave,)),
+                   ('WAVELENGTH',  str(wavelength.dtype), (nwave,)),
+                   ])
+        
     hdr = fits.Header()
     hdr['SPECMIN'] = (specrange[0], 'First spectrum index')
     hx.append(fits.BinTableHDU(a, header=hdr, name='PHOTONS'))

--- a/bin/specter
+++ b/bin/specter
@@ -7,11 +7,14 @@ Stephen Bailey, LBL
 Summer 2013
 """
 
+from __future__ import absolute_import, division, print_function
+
 import sys
 import os
 import numpy as np
 import optparse
 import multiprocessing as MP
+from functools import reduce
 
 #- Parse options
 parser = optparse.OptionParser(
@@ -51,7 +54,7 @@ if opts.inspecmin is None:
 try:
     from astropy.io import fits
 except ImportError:
-    print >> sys.stderr, "ERROR: specter requires astropy.io.fits"
+    print("ERROR: specter requires astropy.io.fits", file=sys.stderr)
     sys.exit(1)
 
 #- If astropy.io.fits was there, safe to proceed with other imports
@@ -69,20 +72,20 @@ if opts.test:
 #- Check input option consistency
 badopts = False
 if opts.input is None:
-    print >> sys.stderr, "ERROR: -i/--input spectra filename required"
+    print("ERROR: -i/--input spectra filename required", file=sys.stderr)
     badopts = True
     
 if opts.output is None:
-    print >> sys.stderr, "ERROR: -o/--output image filename required"
+    print("ERROR: -o/--output image filename required", file=sys.stderr)
     badopts = True
 
 if opts.psf is None:
-    print >> sys.stderr, "ERROR: -p/--psf input psf filename required"
+    print("ERROR: -p/--psf input psf filename required", file=sys.stderr)
     badopts = True
 
 if opts.numcores < 1 or opts.numcores > MP.cpu_count():
-    print >> sys.stderr, "WARNING: overriding numcores %d -> %d" % \
-        (opts.numcores, MP.cpu_count())
+    print("WARNING: overriding numcores {:d} -> {:d}".format(
+        (opts.numcores, MP.cpu_count())), file=sys.stderr)
     opts.numcores = MP.cpu_count()
 
 if badopts:
@@ -103,18 +106,18 @@ if opts.nspec is None:
 
 if opts.specmin+opts.nspec > psf.nspec:
     opts.nspec = psf.nspec - opts.specmin
-    print >> sys.stderr, "WARNING: trimming nspec to {} to fit within {} spectra".format(opts.nspec, psf.nspec)
+    print("WARNING: trimming nspec to {} to fit within {} spectra".format(opts.nspec, psf.nspec), file=sys.stderr)
 
 #- Override default exposure time if needed
 if opts.exptime is not None:
     thru.exptime = opts.exptime
 
-specrange = range(opts.specmin, opts.specmin+opts.nspec)
+specrange = list(range(opts.specmin, opts.specmin+opts.nspec))
 assert max(specrange) < psf.nspec
 
 #-  opts.wavelength is 2-elements min,max
 if opts.wavelength is not None:
-    opts.wavelength = map(float, opts.wavelength.split(','))
+    opts.wavelength = list(map(float, opts.wavelength.split(',')))
     wmin, wmax = opts.wavelength
 else:
     wmin = np.min( psf.wavelength(None, y=-0.5) )        #- bottom edge of CCD
@@ -207,8 +210,8 @@ else:
 if opts.sky:
     sky = specter.io.read_simspec(opts.sky)
     if not units.endswith('/A') or not sky['units'].endswith('/A/arcsec^2'):
-        print "I don't know how to combine these units"
-        print units, sky['units']
+        print("I don't know how to combine these units")
+        print(units, sky['units'])
         sys.exit(1)
     
     for i in range(opts.nspec):
@@ -225,7 +228,7 @@ else:
     xyrange = None
 
 #- Project spectra onto the CCD
-print "Projecting spectra onto CCD"
+print("Projecting spectra onto CCD")
 
 if opts.numcores == 1:
     img = psf.project(wavelength, photons, specmin=specrange[0], xyrange=xyrange)
@@ -238,7 +241,7 @@ else:
     
     #- Setup list of dictionaries with arguments
     arglist = list()
-    n = max(1, (len(specrange)+1)/opts.numcores)
+    n = max(1, (len(specrange)+1)//opts.numcores)
     for i in range(0, len(specrange), n):
         arglist.append(dict(psf=psf, photons=photons[i:i+n],
                          wavelength=wavelength[i:i+n],
@@ -271,7 +274,7 @@ add them
 
 #- Read imput CCD image
 if opts.image:
-    print "Loading input image"
+    print("Loading input image")
     fx = fits.open(opts.image)
     input_image = fx[0].data
     opts.readnoise = 0.0   #- Assume input image already has read noise
@@ -319,9 +322,9 @@ if opts.gaussnoise:
     opts.noise = True
 
 if opts.noise:
-    print "Adding noise"
+    print("Adding noise")
     if opts.gaussnoise:
-        print "Adding Gaussian (not Poisson) noise"
+        print("Adding Gaussian (not Poisson) noise")
         img += np.random.normal(scale=np.sqrt(var))
     else:
         #- photon shot noise (float -> int)
@@ -355,7 +358,7 @@ else:
     output_readnoise = 0.0
         
 #- Write output
-print "Writing", opts.output
+print("Writing", opts.output)
 
 hdr = fits.Header()
 hdr['EXTNAME'] = 'CCDIMAGE'
@@ -386,13 +389,13 @@ hx.append(fits.ImageHDU(1.0/var, name='IVAR'))
 if opts.extra:
     #- Trim arrays to just those with information    
     ii = np.where(np.any(photons>0, axis=0))[0]
-    ii = range(ii[0], ii[-1]+1)
+    ii = list(range(ii[0], ii[-1]+1))
     photons = photons[:, ii]
     wavelength = wavelength[:, ii]
     nwave = wavelength.shape[1]
 
     #- Spectra in photon units
-    a = np.array(zip(photons, wavelength),
+    a = np.array(list(zip(photons, wavelength)),
                 dtype=[('PHOTONS',     str(photons.dtype), (nwave,)),
                        ('WAVELENGTH',  str(wavelength.dtype), (nwave,)),
                        ])
@@ -410,7 +413,7 @@ if opts.extra:
         w[i] = psf.wavelength(ispec=ispec, y=yy)
         x[i] = psf.x(ispec=ispec, wavelength=w[i])
     
-    a = np.array(zip(x, y, w),
+    a = np.array(list(zip(x, y, w)),
                 dtype=[('X', str(x.dtype), (psf.npix_y,)),
                        ('Y', str(y.dtype), (psf.npix_y,)),
                        ('WAVELENGTH',  str(wavelength.dtype), (psf.npix_y,)),

--- a/py/specter/extract/__init__.py
+++ b/py/specter/extract/__init__.py
@@ -77,7 +77,7 @@ rows time
     N.sum(yspot*(yy-yc)**2) / N.sum(yspot)
 """
 
-from __future__ import absolute_import, division, print_function
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 ### from ex1d import ex1d
 from .ex2d import ex2d, ex2d_patch

--- a/py/specter/extract/__init__.py
+++ b/py/specter/extract/__init__.py
@@ -77,5 +77,7 @@ rows time
     N.sum(yspot*(yy-yc)**2) / N.sum(yspot)
 """
 
+from __future__ import absolute_import, division, print_function
+
 ### from ex1d import ex1d
-from ex2d import ex2d, ex2d_patch
+from .ex2d import ex2d, ex2d_patch

--- a/py/specter/extract/ex1d.py
+++ b/py/specter/extract/ex1d.py
@@ -7,7 +7,7 @@ Stephen Bailey, LBL
 Spring 2013
 """
 
-from __future__ import absolute_import, division, print_function
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import sys
 import os

--- a/py/specter/extract/ex1d.py
+++ b/py/specter/extract/ex1d.py
@@ -7,6 +7,8 @@ Stephen Bailey, LBL
 Spring 2013
 """
 
+from __future__ import absolute_import, division, print_function
+
 import sys
 import os
 import numpy as np
@@ -75,7 +77,7 @@ def ex1d(img, mask, psf, readnoise=2.5,
         #- Loop over CCD rows
         for irow, row in enumerate(range(ymin, ymax)):
             if debug and row%500 == 0:
-                print "Row %3d spectra %d:%d" % (row, speclo, spechi)
+                print("Row {:3d} spectra {}:{}".format(row, speclo, spechi))
         
             #- Determine x range covered for this row of this group of spectra
             wlo = psf.wavelength(speclo, y=row)
@@ -124,7 +126,7 @@ def ex1d(img, mask, psf, readnoise=2.5,
             specivar[speclo-specmin:spechi-specmin, row-ymin] = iCov.diagonal()   
             
             if debug:
-                print speclo, row
+                print(speclo, row)
                 import IPython
                 IPython.embed()                
                 

--- a/py/specter/extract/ex2d.py
+++ b/py/specter/extract/ex2d.py
@@ -64,7 +64,7 @@ def ex2d(image, imageivar, psf, specmin, nspec, wavelengths, xyrange=None,
             ndiag = max(ndiag, int(round(9.0*psf.wdisp(ispec, w) / dw )))
 
     #- make sure that ndiag isn't too large for actual PSF spot size
-    wmid = (psf.wmin_all + psf.wmax_all) / 2
+    wmid = (psf.wmin_all + psf.wmax_all) / 2.0
     spotsize = psf.pix(0, wmid).shape
     ndiag = min(ndiag, spotsize[0]//2, spotsize[1]//2)
 
@@ -244,7 +244,7 @@ def ex2d_patch(image, ivar, psf, specmin, nspec, wavelengths, xyrange=None,
             R, fluxivar = resolution_from_icov(iCov)
         else:
             R, fluxivar = resolution_from_icov(iCov, decorr=[nwave for x in range(nspec)])
-    except np.linalg.linalg.LinAlgError, err:
+    except np.linalg.linalg.LinAlgError as err:
         outfile = 'LinAlgError_{}-{}_{}-{}.fits'.format(specrange[0], specrange[1], waverange[0], waverange[1])
         print("ERROR: Linear Algebra didn't converge")
         print("Dumping {} for debugging".format(outfile))

--- a/py/specter/extract/ex2d.py
+++ b/py/specter/extract/ex2d.py
@@ -1,7 +1,7 @@
 """
 2D Spectroperfectionism extractions
 """
-from __future__ import absolute_import, division, print_function
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import sys
 import numpy as np

--- a/py/specter/io.py
+++ b/py/specter/io.py
@@ -9,7 +9,7 @@ Stephen Bailey, LBL
 January 2013
 """
 
-from __future__ import absolute_import, division, print_function
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import os
 import os.path

--- a/py/specter/io.py
+++ b/py/specter/io.py
@@ -9,6 +9,8 @@ Stephen Bailey, LBL
 January 2013
 """
 
+from __future__ import absolute_import, division, print_function
+
 import os
 import os.path
 from astropy.io import fits
@@ -174,7 +176,7 @@ def read_simspec_table(filename):
     elif 'BUNIT' in header:
         units = header['BUNIT'].strip()
     else:
-        print >> sys.stderr, 'WARNING: using default flux units of erg/s/cm^2/A'
+        print('WARNING: using default flux units of erg/s/cm^2/A', file=sys.stderr)
         units = 'erg/s/cm^2/A'
 
     #- return results

--- a/py/specter/psf/__init__.py
+++ b/py/specter/psf/__init__.py
@@ -2,13 +2,15 @@
 specter.psf
 ===========
 """
-from psf import PSF
-from spotgrid import SpotGridPSF
-from pixpsf import PixPSF
-from monospot import MonoSpotPSF
-from monospot import MonoSpotPSF
-from gausshermite import GaussHermitePSF
-from gausshermite2 import GaussHermite2PSF
+from __future__ import absolute_import, division, print_function
+
+from .psf import PSF
+from .spotgrid import SpotGridPSF
+from .pixpsf import PixPSF
+from .monospot import MonoSpotPSF
+from .monospot import MonoSpotPSF
+from .gausshermite import GaussHermitePSF
+from .gausshermite2 import GaussHermite2PSF
 
 def load_psf(filename, psftype=None):
     """
@@ -34,5 +36,5 @@ def load_psf(filename, psftype=None):
     elif hdr['PSFTYPE'].strip() == 'GAUSS-HERMITE2':
         return GaussHermite2PSF(filename)
     else:
-        print "Unknown PSFTYPE", hdr['PSFTYPE']
+        print("Unknown PSFTYPE {}".format(hdr['PSFTYPE']))
         return PSF(filename)

--- a/py/specter/psf/__init__.py
+++ b/py/specter/psf/__init__.py
@@ -2,7 +2,7 @@
 specter.psf
 ===========
 """
-from __future__ import absolute_import, division, print_function
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 from .psf import PSF
 from .spotgrid import SpotGridPSF

--- a/py/specter/psf/gausshermite.py
+++ b/py/specter/psf/gausshermite.py
@@ -7,7 +7,7 @@ Stephen Bailey
 December 2013
 """
 
-from __future__ import absolute_import, division, print_function
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import sys
 import os

--- a/py/specter/psf/gausshermite.py
+++ b/py/specter/psf/gausshermite.py
@@ -7,6 +7,8 @@ Stephen Bailey
 December 2013
 """
 
+from __future__ import absolute_import, division, print_function
+
 import sys
 import os
 import numpy as np
@@ -29,16 +31,16 @@ class GaussHermitePSF(PSF):
         fx = fits.open(filename, memmap=False)
         self._polyparams = hdr = fx[1].header
         if 'PSFTYPE' not in hdr:
-            raise ValueError, 'Missing PSFTYPE keyword'
+            raise ValueError('Missing PSFTYPE keyword')
             
         if hdr['PSFTYPE'] != 'GAUSS-HERMITE':
-            raise ValueError, 'PSFTYPE %s is not GAUSS-HERMITE' % hdr['PSFTYPE']
+            raise ValueError('PSFTYPE {} is not GAUSS-HERMITE'.format(hdr['PSFTYPE']))
             
         if 'PSFVER' not in hdr:
-            raise ValueError, "PSFVER missing; this version not supported"
+            raise ValueError("PSFVER missing; this version not supported")
             
         if hdr['PSFVER'] < '1':
-            raise ValueError, "Only GAUSS-HERMITE versions 1.0 and greater are supported"
+            raise ValueError("Only GAUSS-HERMITE versions 1.0 and greater are supported")
             
         #- Calculate number of spectra from FIBERMIN and FIBERMAX (inclusive)
         self.nspec = hdr['FIBERMAX'] - hdr['FIBERMIN'] + 1

--- a/py/specter/psf/gausshermite2.py
+++ b/py/specter/psf/gausshermite2.py
@@ -10,6 +10,8 @@ TODO: GaussHermitePSF (no 2) was copied and pasted from this and then
       modified.  Can they be refactored to share code?
 """
 
+from __future__ import absolute_import, division, print_function
+
 import sys
 import os
 import numpy as np
@@ -32,16 +34,16 @@ class GaussHermite2PSF(PSF):
         fx = fits.open(filename, memmap=False)
         self._polyparams = hdr = fx[1].header
         if 'PSFTYPE' not in hdr:
-            raise ValueError, 'Missing PSFTYPE keyword'
+            raise ValueError('Missing PSFTYPE keyword')
             
         if hdr['PSFTYPE'] != 'GAUSS-HERMITE2':
-            raise ValueError, 'PSFTYPE %s is not GAUSS-HERMITE' % hdr['PSFTYPE']
+            raise ValueError('PSFTYPE {} is not GAUSS-HERMITE'.format(hdr['PSFTYPE']))
             
         if 'PSFVER' not in hdr:
-            raise ValueError, "PSFVER missing; this version not supported"
+            raise ValueError("PSFVER missing; this version not supported")
             
         if hdr['PSFVER'] < '1':
-            raise ValueError, "Only GAUSS-HERMITE versions 1.0 and greater are supported"
+            raise ValueError("Only GAUSS-HERMITE versions 1.0 and greater are supported")
             
         #- Calculate number of spectra from FIBERMIN and FIBERMAX (inclusive)
         self.nspec = hdr['FIBERMAX'] - hdr['FIBERMIN'] + 1

--- a/py/specter/psf/gausshermite2.py
+++ b/py/specter/psf/gausshermite2.py
@@ -10,7 +10,7 @@ TODO: GaussHermitePSF (no 2) was copied and pasted from this and then
       modified.  Can they be refactored to share code?
 """
 
-from __future__ import absolute_import, division, print_function
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import sys
 import os

--- a/py/specter/psf/monospot.py
+++ b/py/specter/psf/monospot.py
@@ -58,8 +58,8 @@ class MonoSpotPSF(PSF):
         ccdpix /= np.sum(ccdpix)
 
         #- Find where the [0,0] pixel goes on the CCD 
-        xccd = int(xc - ccdpix.shape[1]/2 + 1)
-        yccd = int(yc - ccdpix.shape[0]/2 + 1)
+        xccd = int(xc - ccdpix.shape[1]//2 + 1)
+        yccd = int(yc - ccdpix.shape[0]//2 + 1)
 
         xx = slice(xccd, xccd+ccdpix.shape[1])
         yy = slice(yccd, yccd+ccdpix.shape[0])

--- a/py/specter/psf/monospot.py
+++ b/py/specter/psf/monospot.py
@@ -2,6 +2,8 @@
 MonoSpotPSF - ...
 """
 
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 import numpy as np
 from astropy.io import fits
 from specter.psf import PSF

--- a/py/specter/psf/pixpsf.py
+++ b/py/specter/psf/pixpsf.py
@@ -73,22 +73,22 @@ class PixPSF(PSF):
         ix = int(round(x))
         iy = int(round(y))
         
-        xmin = max(0, ix-nx/2)
-        xmax = min(self.npix_x, ix+nx/2+1)
-        ymin = max(0, iy-ny/2)
-        ymax = min(self.npix_y, iy+ny/2+1)
+        xmin = max(0, ix-nx//2)
+        xmax = min(self.npix_x, ix+nx//2+1)
+        ymin = max(0, iy-ny//2)
+        ymax = min(self.npix_y, iy+ny//2+1)
                 
-        if ix < nx/2:
-            psfimage = psfimage[:, nx/2-ix:]
-        if iy < ny/2:
-            psfimage = psfimage[ny/2-iy:, :]
+        if ix < nx//2:
+            psfimage = psfimage[:, nx//2-ix:]
+        if iy < ny//2:
+            psfimage = psfimage[ny//2-iy:, :]
         
-        if ix+nx/2+1 > self.npix_x:
-            dx = self.npix_x - (ix+nx/2+1)
+        if ix+nx//2+1 > self.npix_x:
+            dx = self.npix_x - (ix+nx//2+1)
             psfimage = psfimage[:, :dx]
             
-        if iy+ny/2+1 > self.npix_y:
-            dy = self.npix_y - (iy+ny/2+1)
+        if iy+ny//2+1 > self.npix_y:
+            dy = self.npix_y - (iy+ny//2+1)
             psfimage = psfimage[:dy, :]
         
         xslice = slice(xmin, xmax)
@@ -100,5 +100,8 @@ class PixPSF(PSF):
         #- Normalize integral to 1.0
         psfimage /= psfimage.sum()
         
+        assert xslice.stop-xslice.start == psfimage.shape[1]
+        assert yslice.stop-yslice.start == psfimage.shape[0]
+
         return xslice, yslice, psfimage
 

--- a/py/specter/psf/pixpsf.py
+++ b/py/specter/psf/pixpsf.py
@@ -6,6 +6,8 @@ Pixelated 2D PSF
 David Schlegel & Stephen Bailey, Summer 2011
 """
 
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 import numpy as np
 from astropy.io import fits
 from specter.psf import PSF

--- a/py/specter/psf/psf.py
+++ b/py/specter/psf/psf.py
@@ -12,7 +12,10 @@ the interface defined in this base class.
 Stephen Bailey, Fall 2012
 """
 
+from __future__ import absolute_import, division, print_function
+
 import sys
+import numbers
 import numpy as np
 from numpy.polynomial.legendre import Legendre, legval, legfit
 import scipy.optimize
@@ -91,7 +94,7 @@ class PSF(object):
             elif axis in ('y', 'Y', 'w', 'W'):
                 axis = 1
             else:
-                raise ValueError("Unknown axis type "+str(axis))
+                raise ValueError("Unknown axis type {}".format(axis))
                 
         if axis not in (0,1):
             raise ValueError("axis must be 0, 'x', 1, 'y', or 'w'")
@@ -104,6 +107,7 @@ class PSF(object):
             xspot /= np.sum(xspot)       #- normalize for edge cases
             xx = np.arange(len(xspot))
             mean, sigma = scipy.optimize.curve_fit(gausspix, xx, xspot)[0]
+                
             xsig.append(sigma)
         
         #- Fit Legendre polynomial and return coefficients
@@ -260,7 +264,7 @@ class PSF(object):
             xhi = xmax
 
         if ylo < ymin:
-            ccdpix = ccdpix[-(yhi-ymin):, ]
+            ccdpix = ccdpix[-(yhi-ymin):, ]                
             ylo = ymin
         elif yhi > ymax:
             ccdpix = ccdpix[0:(ymax-ylo), :]
@@ -288,12 +292,12 @@ class PSF(object):
         BUG: will fail if asking for a range where one of the spectra is
         completely off the CCD
         """
-        if isinstance(spec_range, int):
+        if isinstance(spec_range, numbers.Integral):
             specmin, specmax = spec_range, spec_range+1
         else:
             specmin, specmax = spec_range
 
-        if isinstance(wavelengths, (int, float)):
+        if isinstance(wavelengths, numbers.Real):
             wavemin = wavemax = wavelengths
         else:
             wavemin, wavemax = wavelengths[0], wavelengths[-1]
@@ -393,7 +397,7 @@ class PSF(object):
         if wavelength is None:
             #- ispec=None -> ispec=every spectrum
             if ispec is None:
-                ispec = np.arange(self.nspec)
+                ispec = np.arange(self.nspec, dtype=int)
             
             #- ispec is an array; sample at every row
             if isinstance(ispec, (np.ndarray, list, tuple)):
@@ -424,7 +428,7 @@ class PSF(object):
         vector  vector      array[nspec, nwave]
         """
         if wavelength is None:
-            raise ValueError, "PSF.y requires wavelength scalar or vector"
+            raise ValueError("PSF.y requires wavelength scalar or vector")
             
         if ispec is None:
             ispec = np.arange(self.nspec)
@@ -435,7 +439,7 @@ class PSF(object):
             if wavelength is None:
                 return np.tile(np.arange(self.npix_y), self.nspec).reshape(self.nspec, self.npix_y)
             else:
-                ispec = np.arange(self.nspec)
+                ispec = np.arange(self.nspec, dtype=int)
         
         if wavelength is None:
             wavelength = self.wavelength(ispec)
@@ -462,9 +466,9 @@ class PSF(object):
         """
         if y is None:
             y = np.arange(0, self.npix_y)
-        
+                
         if ispec is None:
-            ispec = np.arange(self.nspec)
+            ispec = np.arange(self.nspec, dtype=int)
             
         return self._w.eval(ispec, y)
     
@@ -519,7 +523,7 @@ class PSF(object):
         if specmin >= self.nspec:
             raise ValueError('specmin {} >= psf.nspec {}'.format(specmin, self.nspec))
         if specmin+phot.shape[0] > self.nspec:
-            print >> sys.stderr, "WARNING: specmin+npec ({}+{}) > psf.nspec {}".format(specmin, phot.shape[0], self.nspec)
+            print("WARNING: specmin+npec ({}+{}) > psf.nspec {}".format(specmin, phot.shape[0], self.nspec), file=sys.stderr)
         
         #- x,y ranges and number of pixels
         if xyrange is None:
@@ -543,7 +547,7 @@ class PSF(object):
         specmax = min(specmin+nspec, self.nspec)
         for i, ispec in enumerate(range(specmin, specmax)):
             if verbose:
-                print ispec
+                print(ispec)
             
             #- 1D wavelength for every spec, or 2D wavelength for 2D phot?
             if wavelength.ndim == 2:
@@ -602,7 +606,7 @@ class PSF(object):
         """
     
         #- Matrix dimensions
-        if isinstance(spec_range, int):
+        if isinstance(spec_range, numbers.Integral):
             specmin, specmax = spec_range, spec_range+1
         else:
             specmin, specmax = spec_range
@@ -622,7 +626,7 @@ class PSF(object):
                 xslice, yslice, pix = self.xypix(ispec, w, xmin=xmin, xmax=xmax, ymin=ymin, ymax=ymax)
                 
                 #- If there is overlap with pix_range, put into sub-region of A
-                if pix.shape[0]>0 and pix.shape[1]>0:         
+                if pix.shape[0]>0 and pix.shape[1]>0:
                     tmp[yslice, xslice] = pix
                     ij = (ispec-specmin)*nflux + iflux
                     A[:, ij] = tmp.ravel()

--- a/py/specter/psf/psf.py
+++ b/py/specter/psf/psf.py
@@ -12,7 +12,7 @@ the interface defined in this base class.
 Stephen Bailey, Fall 2012
 """
 
-from __future__ import absolute_import, division, print_function
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import sys
 import numbers

--- a/py/specter/psf/spotgrid.py
+++ b/py/specter/psf/spotgrid.py
@@ -66,8 +66,8 @@ class SpotGridPSF(PSF):
         pix_spot_values=self._fspot(p, w)
         nx_spot=pix_spot_values.shape[1]
         ny_spot=pix_spot_values.shape[0]
-        nx_ccd=nx_spot/rebin+1 # add one bin because of resampling
-        ny_ccd=ny_spot/rebin+1 # add one bin because of resampling
+        nx_ccd=nx_spot//rebin+1 # add one bin because of resampling
+        ny_ccd=ny_spot//rebin+1 # add one bin because of resampling
         
         xc, yc = self.xy(ispec, wavelength) # center of PSF in CCD coordinates
                 
@@ -95,12 +95,12 @@ class SpotGridPSF(PSF):
         # make sure it's positive
         ccd_pix_spot_values[ccd_pix_spot_values<0]=0.
         # normalize
-        n=np.sum(ccd_pix_spot_values)
-        if n>0 :
-            ccd_pix_spot_values /= n
+        norm = np.sum(ccd_pix_spot_values)
+        if norm > 0 :
+            ccd_pix_spot_values /= norm
 
-        x_ccd_begin = int(np.floor(xc))-nx_ccd/2+1  # begin of CCD coordinate stamp
-        y_ccd_begin = int(np.floor(yc))-ny_ccd/2+1  # begin of CCD coordinate stamp
+        x_ccd_begin = int(np.floor(xc))-nx_ccd//2+1  # begin of CCD coordinate stamp
+        y_ccd_begin = int(np.floor(yc))-ny_ccd//2+1  # begin of CCD coordinate stamp
         xx = slice(x_ccd_begin, (x_ccd_begin+nx_ccd))
         yy = slice(y_ccd_begin, (y_ccd_begin+ny_ccd))
         return xx,yy,ccd_pix_spot_values

--- a/py/specter/psf/spotgrid.py
+++ b/py/specter/psf/spotgrid.py
@@ -6,6 +6,8 @@ Stephen Bailey
 Fall 2012
 """
 
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 import sys
 import os
 import numpy as np

--- a/py/specter/test/squeeze_gausshermite_psf.py
+++ b/py/specter/test/squeeze_gausshermite_psf.py
@@ -5,6 +5,8 @@ Squeeze a DESI GAUSS-HERMITE PSF into something smaller for testing.
 Also works for GAUSS-HERMITE2
 """
 
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 import sys
 import numpy as np
 from astropy.io import fits

--- a/py/specter/test/squeeze_spot_psf.py
+++ b/py/specter/test/squeeze_spot_psf.py
@@ -4,6 +4,8 @@
 Take a BigBOSS spotgrid PSF and trim it down for testing
 """
 
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 import sys
 import os
 import numpy as np

--- a/py/specter/test/test_binscripts.py
+++ b/py/specter/test/test_binscripts.py
@@ -3,7 +3,7 @@
 """
 Unit tests for executable scripts in specter/bin
 """
-from __future__ import absolute_import, division, print_function
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import os
 import sys

--- a/py/specter/test/test_binscripts.py
+++ b/py/specter/test/test_binscripts.py
@@ -3,7 +3,8 @@
 """
 Unit tests for executable scripts in specter/bin
 """
-from __future__ import print_function
+from __future__ import absolute_import, division, print_function
+
 import os
 import sys
 import numpy as np
@@ -11,7 +12,7 @@ import unittest
 from astropy.io import fits
 from uuid import uuid4
 from pkg_resources import resource_filename
-from ..io import read_image, write_spectra
+from specter.io import read_image, write_spectra
 from astropy.io import fits
 
 _base = uuid4().hex
@@ -23,19 +24,44 @@ specfile2 = 'testspec2-'+_base+'.fits'
 
 class TestBinScripts(unittest.TestCase):
 
-    def setUp(self):
-        self.specter_dir = os.path.dirname( # top-level
+    @classmethod
+    def setUpClass(cls):
+        #- when running "python setup.py test", this file is run from different
+        #- locations for python 2.7 vs. 3.5
+        #- python 2.7: py/specter/test/test_binscripts.py
+        #- python 3.5: build/lib/specter/test/test_binscripts.py
+        
+        #- python 2.7 location:
+        cls.specter_dir = os.path.dirname( # top-level
             os.path.dirname( # py/
                 os.path.dirname( # specter/
                     os.path.dirname(os.path.abspath(__file__)) # test/
                     )
                 )
             )
-        self.executable = sys.executable
-        self.sky_file = resource_filename('specter', 'data/sky-uves.fits')
-        self.monospot_file = resource_filename('specter.test', 't/psf-monospot.fits')
-        self.throughput_file = resource_filename('specter.test', 't/throughput.fits')
-        self.exspec_cmd = """{executable} {specter_dir}/bin/exspec \
+        if not os.path.isdir(cls.specter_dir + '/bin'):
+            #- python 3.x setup.py test location:
+            cls.specter_dir = os.path.dirname( # top-level
+                os.path.dirname( # build/
+                    os.path.dirname( # lib/
+                        os.path.dirname( # specter/
+                            os.path.dirname(os.path.abspath(__file__)) # test/
+                            )
+                        )
+                    )
+                )
+        #- last attempt
+        if not os.path.isdir(cls.specter_dir + '/bin'):
+            cls.specter_dir = os.path.join(os.getcwd(), 'bin')
+
+        if not os.path.isdir(cls.specter_dir + '/bin'):
+            raise RuntimeError('Unable to auto-locate specter/bin from {}'.format(__file__))
+            
+        cls.executable = sys.executable
+        cls.sky_file = resource_filename('specter', 'data/sky-uves.fits')
+        cls.monospot_file = resource_filename('specter.test', 't/psf-monospot.fits')
+        cls.throughput_file = resource_filename('specter.test', 't/throughput.fits')
+        cls.exspec_cmd = """{executable} {specter_dir}/bin/exspec \
           -i {imgfile} \
           -p {monospot_file} \
           -o {specfile} \
@@ -44,17 +70,18 @@ class TestBinScripts(unittest.TestCase):
 
         #- Add this package to PYTHONPATH so that binscripts can find it
         try:
-            self.origPath = os.environ['PYTHONPATH']
-            os.environ['PYTHONPATH'] = os.path.join(self.specter_dir,'py') + ':' + self.origPath
+            cls.origPath = os.environ['PYTHONPATH']
+            os.environ['PYTHONPATH'] = os.path.join(cls.specter_dir,'py') + ':' + cls.origPath
         except KeyError:
-            self.origPath = None
-            os.environ['PYTHONPATH'] = os.path.join(self.specter_dir,'py')
+            cls.origPath = None
+            os.environ['PYTHONPATH'] = os.path.join(cls.specter_dir,'py')
 
-    def tearDown(self):
-        if self.origPath is None:
+    @classmethod
+    def tearDownClass(cls):
+        if cls.origPath is None:
             del os.environ['PYTHONPATH']
         else:
-            os.environ['PYTHONPATH'] = self.origPath
+            os.environ['PYTHONPATH'] = cls.origPath
 
     def test_aa(self):
         cmd = """{executable} {specter_dir}/bin/specter \

--- a/py/specter/test/test_extract.py
+++ b/py/specter/test/test_extract.py
@@ -4,6 +4,8 @@
 Unit tests for extraction.
 """
 
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 import sys
 import os
 import numpy as np

--- a/py/specter/test/test_pixspline.py
+++ b/py/specter/test/test_pixspline.py
@@ -1,3 +1,5 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 import unittest
 import numpy as np
 from specter.util import pixspline

--- a/py/specter/test/test_pixspline.py
+++ b/py/specter/test/test_pixspline.py
@@ -1,6 +1,6 @@
 import unittest
 import numpy as np
-from ..util import pixspline
+from specter.util import pixspline
 
 class TestPixSpline(unittest.TestCase):
     """
@@ -45,11 +45,11 @@ class TestPixSpline(unittest.TestCase):
             self.assertTrue(sp.point_evaluate(x[i]) == yy[i])
 
         #- Rebinning
-        y2 = y.reshape((nx/2,2)).mean(1)
+        y2 = y.reshape((nx//2,2)).mean(1)
         dy2 = sp.resample(edges[0::2]) - y2
         self.assertTrue(np.max(np.abs(dy2)) < 1e-12)
 
-        y5 = y.reshape((nx/5,5)).mean(1)
+        y5 = y.reshape((nx//5,5)).mean(1)
         dy5 = sp.resample(edges[0::5]) - y5
         self.assertTrue(np.max(np.abs(dy5)) < 1e-12)
 

--- a/py/specter/test/test_psf.py
+++ b/py/specter/test/test_psf.py
@@ -3,7 +3,7 @@
 """
 Unit tests for PSF classes.
 """
-from __future__ import absolute_import, division, print_function
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import sys
 import os

--- a/py/specter/test/test_psf.py
+++ b/py/specter/test/test_psf.py
@@ -3,13 +3,14 @@
 """
 Unit tests for PSF classes.
 """
+from __future__ import absolute_import, division, print_function
 
 import sys
 import os
 import numpy as np
 import unittest
 from pkg_resources import resource_filename
-from ..psf import load_psf
+from specter.psf import load_psf
 
 class GenericPSFTests(object):
     """
@@ -55,8 +56,8 @@ class GenericPSFTests(object):
 
     #- Test xsigma
     def test_xsigma(self):
-        yy = (20, self.psf.npix_y/2, self.psf.npix_y-20)
-        for ispec in (0, self.psf.nspec/2, self.psf.nspec-1):
+        yy = (20, self.psf.npix_y//2, self.psf.npix_y-20)
+        for ispec in (0, self.psf.nspec//2, self.psf.nspec-1):
             ww = self.psf.wavelength(ispec, y=yy)
             #- Get xsigma for several wavelengths at once
             xsig1 = self.psf.xsigma(ispec, ww)
@@ -77,8 +78,8 @@ class GenericPSFTests(object):
 
     #- Test wdisp
     def test_wdisp(self):
-        yy = (20, self.psf.npix_y/2, self.psf.npix_y-20)
-        for ispec in (0, self.psf.nspec/2, self.psf.nspec-1):
+        yy = (20, self.psf.npix_y//2, self.psf.npix_y-20)
+        for ispec in (0, self.psf.nspec//2, self.psf.nspec-1):
             ww = self.psf.wavelength(ispec, y=yy)
             #- Get wdisp for several wavelengths at once
             xsig1 = self.psf.wdisp(ispec, ww)
@@ -108,10 +109,10 @@ class GenericPSFTests(object):
         wtest.append(np.max(ww[:, -1]))
         wtest.append(np.mean(wtest))
 
-        for i in (0, self.psf.nspec/2, self.psf.nspec-1):
+        for i in (0, self.psf.nspec//2, self.psf.nspec-1):
             for w in wtest:
                 pix = self.psf.pix(i, w)
-                self.assertEquals(pix.ndim, 2)
+                self.assertEqual(pix.ndim, 2)
 
     #- Test that PSF spots are normalized to 1.0
     def test_pix_norm(self):
@@ -144,9 +145,9 @@ class GenericPSFTests(object):
         wtest.append(np.mean(wtest))
         wtest.append(np.min(ww)-100)
 
-        for i in (0, self.psf.nspec/2, self.psf.nspec-1):
+        for i in (0, self.psf.nspec//2, self.psf.nspec-1):
             for w in wtest:
-                xx, yy, pix = self.psf.xypix(self.psf.nspec/2, w)
+                xx, yy, pix = self.psf.xypix(self.psf.nspec//2, w)
                 shape = (yy.stop-yy.start, xx.stop-xx.start)
                 msg = "%s != %s at (i=%d, w=%.1f)" % (str(pix.shape), str(shape), i, w)
                 self.assertEqual(pix.shape, shape, msg)
@@ -156,7 +157,7 @@ class GenericPSFTests(object):
     #- TODO: Better tests when walking off edge
     def test_xypix_range(self):
         w = np.mean(self.psf.wavelength())
-        i = self.psf.nspec/2
+        i = self.psf.nspec//2
         x0, y0, pix = self.psf.xypix(i, w)
         xx, yy, pix = self.psf.xypix(i, w, xmin=x0.start)
         self.assertTrue(xx.start == 0)
@@ -206,7 +207,7 @@ class GenericPSFTests(object):
         ww = self.psf.wavelength(0)[0:10]
         phot = np.random.uniform(0,100,len(ww))
         img = self.psf.project(ww, phot, verbose=False)
-        self.assertEquals(img.shape, (self.psf.npix_y, self.psf.npix_x))
+        self.assertEqual(img.shape, (self.psf.npix_y, self.psf.npix_x))
 
     #- Test projection of 2D spectrum with shared 1D wavelength vector
     def test_project12(self):
@@ -214,7 +215,7 @@ class GenericPSFTests(object):
         phot = np.random.uniform(0,100,len(ww))
         phot = np.tile(phot, 5).reshape(5, len(ww))
         img = self.psf.project(ww, phot, verbose=False)
-        self.assertEquals(img.shape, (self.psf.npix_y, self.psf.npix_x))
+        self.assertEqual(img.shape, (self.psf.npix_y, self.psf.npix_x))
 
     #- Test projection of 2D spectrum with 2D wavelength vector
     def test_project22(self):
@@ -224,14 +225,14 @@ class GenericPSFTests(object):
         phot = np.random.uniform(0,100,nw)
         phot = np.tile(phot, 5).reshape(5, nw)
         img = self.psf.project(ww, phot, verbose=False)
-        self.assertEquals(img.shape, (self.psf.npix_y, self.psf.npix_x))
+        self.assertEqual(img.shape, (self.psf.npix_y, self.psf.npix_x))
 
     #- Test projection starting at specmin != 0
     def test_project_specmin(self):
         ww = self.psf.wavelength(0)[0:10]
         phot = np.random.uniform(0,100,len(ww))
         img = self.psf.project(ww, phot, specmin=1, verbose=False)
-        self.assertEquals(img.shape, (self.psf.npix_y, self.psf.npix_x))
+        self.assertEqual(img.shape, (self.psf.npix_y, self.psf.npix_x))
 
         #- specmin >= nspec should raise an error
         with self.assertRaises(ValueError):
@@ -282,7 +283,7 @@ class GenericPSFTests(object):
         nw = 20
         w_edge = 10  #- avoid edge effects; test that separately
         phot = np.random.uniform(100,1000, size=(nspec, nw))
-        for specmin in (0, self.psf.nspec/2, self.psf.nspec-nspec-1):
+        for specmin in (0, self.psf.nspec//2, self.psf.nspec-nspec-1):
             specrange = (specmin, specmin+nspec)
             wspec = self.psf.wavelength(specmin, [0, self.psf.npix_y])
             for wmin in (wspec[0]+w_edge, 0.5*(wspec[0]+wspec[1]), wspec[1]-nw-w_edge):
@@ -312,7 +313,7 @@ class GenericPSFTests(object):
     def test_xyrange_edges(self):
         psf = self.psf
         y = np.arange(-1, psf.npix_y, 0.2)
-        for i in range(0, psf.nspec, psf.nspec/10):
+        for i in range(0, psf.nspec, psf.nspec//10):
             w = psf.wavelength(i, y)
             xmin, xmax, ymin, ymax = psf.xyrange(i, w)
             self.assertTrue(xmin <= xmax)
@@ -405,7 +406,7 @@ class GenericPSFTests(object):
 
     #- Ensure that pix requests outside of wavelength range are blank
     def test_waverange_pix(self):
-        for ispec in (0, 1, self.psf.nspec/2, self.psf.nspec-1):
+        for ispec in (0, 1, self.psf.nspec//2, self.psf.nspec-1):
             xx, yy, pix = self.psf.xypix(ispec, self.psf.wmin-1)
             self.assertTrue(xx.start == xx.stop == 0)
             self.assertTrue(yy.start == yy.stop == 0)
@@ -516,6 +517,9 @@ class TestGaussHermite2PSF(GenericPSFTests,unittest.TestCase):
 
 if __name__ == '__main__':
 
+    import warnings
+    warnings.simplefilter('error')
+
     # unittest.main()
     s1 = unittest.defaultTestLoader.loadTestsFromTestCase(TestPixPSF)
     s2 = unittest.defaultTestLoader.loadTestsFromTestCase(TestSpotPSF)
@@ -524,3 +528,4 @@ if __name__ == '__main__':
     s5 = unittest.defaultTestLoader.loadTestsFromTestCase(TestGaussHermite2PSF)
 
     unittest.TextTestRunner(verbosity=2).run(unittest.TestSuite([s1, s2, s3, s4, s5]))
+    # unittest.TextTestRunner(verbosity=2).run(unittest.TestSuite([s2,]))

--- a/py/specter/test/test_specio.py
+++ b/py/specter/test/test_specio.py
@@ -5,6 +5,8 @@ Test Specter file formats.  Loop over example files and just make sure
 that we can read them.
 """
 
+from __future__ import absolute_import, division, print_function
+
 import os
 from os.path import basename, join
 from glob import glob
@@ -24,7 +26,7 @@ class TestSpecIO(unittest.TestCase):
             try:
                 x = read_simspec(specfile)
             except Exception as e:
-                print "Failed on {0}: {1}".format(basename(specfile), str(e))
+                print("Failed on {0}: {1}".format(basename(specfile), str(e)))
                 wipeout = e
         if wipeout:
             raise wipeout

--- a/py/specter/test/test_specio.py
+++ b/py/specter/test/test_specio.py
@@ -5,7 +5,7 @@ Test Specter file formats.  Loop over example files and just make sure
 that we can read them.
 """
 
-from __future__ import absolute_import, division, print_function
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import os
 from os.path import basename, join

--- a/py/specter/test/test_throughput.py
+++ b/py/specter/test/test_throughput.py
@@ -4,6 +4,8 @@
 Test specter throughput file format
 """
 
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 import os
 import numpy as np
 import unittest

--- a/py/specter/test/test_util.py
+++ b/py/specter/test/test_util.py
@@ -4,6 +4,8 @@
 Unit tests for PSF classes.
 """
 
+from __future__ import absolute_import, division, print_function
+
 import sys
 import os
 import numpy as np
@@ -11,7 +13,7 @@ from numpy.polynomial import legendre
 from specter import util
 import unittest
 from pkg_resources import resource_filename
-from ..psf import load_psf
+from specter.psf import load_psf
 
 class TestUtil(unittest.TestCase):
     """

--- a/py/specter/test/test_util.py
+++ b/py/specter/test/test_util.py
@@ -4,7 +4,7 @@
 Unit tests for PSF classes.
 """
 
-from __future__ import absolute_import, division, print_function
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import sys
 import os

--- a/py/specter/test/write_input_spectra.py
+++ b/py/specter/test/write_input_spectra.py
@@ -5,6 +5,8 @@ Write a suite of input spectra files with different formats, units,
 1D vs. 2D, etc. to use with testing.
 """
 
+from __future__ import absolute_import, division, print_function
+
 import sys
 import os
 import numpy as np
@@ -116,8 +118,8 @@ for flux in (flux1D, flux2D):
                 else:
                     objtype_str = ' %-6s' % objtype
                 
-                print filename, 'image', objtype_str, loglam, wdim, flux.ndim
+                print(filename, 'image', objtype_str, loglam, wdim, flux.ndim)
                 if (wave is not None) and (flux.ndim == wave.ndim):
                     filename = write_tblspec(flux, xwave, loglam, objtype)
-                    print filename, 'table', objtype_str, loglam, wdim, flux.ndim
+                    print(filename, 'table', objtype_str, loglam, wdim, flux.ndim)
 

--- a/py/specter/test/write_input_spectra.py
+++ b/py/specter/test/write_input_spectra.py
@@ -5,7 +5,7 @@ Write a suite of input spectra files with different formats, units,
 1D vs. 2D, etc. to use with testing.
 """
 
-from __future__ import absolute_import, division, print_function
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import sys
 import os

--- a/py/specter/throughput.py
+++ b/py/specter/throughput.py
@@ -15,7 +15,7 @@ Hacks:
 How to handle fiber size and sky units?
 """
 
-from __future__ import absolute_import, division, print_function
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import sys
 import os

--- a/py/specter/throughput.py
+++ b/py/specter/throughput.py
@@ -15,9 +15,12 @@ Hacks:
 How to handle fiber size and sky units?
 """
 
+from __future__ import absolute_import, division, print_function
+
 import sys
 import os
 import warnings
+import numbers
 import numpy as np
 from astropy.io import fits
 from specter import util
@@ -50,7 +53,7 @@ def load_throughput(filename):
         for key in tmp.dtype.names:
             fiberinput[key.upper()] = tmp[key]
     else:
-        print "no FIBERINPUT extention found"
+        print("no FIBERINPUT extention found")
         fiberinput = thru['fiberinput']
 
     if 'wavelength' in thru.dtype.names:
@@ -59,7 +62,7 @@ def load_throughput(filename):
         w = 10**thru['loglam']
     else:
         fx.close()
-        raise ValueError, 'throughput must include wavelength or loglam'
+        raise ValueError('throughput must include wavelength or loglam')
 
     if 'GEOMAREA' in hdr:
         area = hdr['GEOMAREA']
@@ -125,7 +128,7 @@ class Throughput:
 
         #- Create fiber input dict keyed by object type, including 'default'
         if fiberinput is not None:
-            if isinstance(fiberinput, float):
+            if isinstance(fiberinput, numbers.Real):
                 self._fiberinput = dict(default=np.ones(len(wave)) * fiberinput)
             elif isinstance(fiberinput, np.ndarray):
                 self._fiberinput = dict(default=np.copy(fiberinput))
@@ -134,7 +137,7 @@ class Throughput:
                 if 'default' not in fiberinput:
                     self._fiberinput['default'] = np.ones(len(wave))
             else:
-                raise ValueError('Unrecognized type for fiberinput: '+str(type(fiberinput)))
+                raise ValueError('Unrecognized type for fiberinput: {}'.format(type(fiberinput)))
         else:
             self._fiberinput = dict(default=np.ones(len(wave)))
 
@@ -175,7 +178,7 @@ class Throughput:
             t = self._fiberinput[objtype]
         else:
             msg = 'Unknown objtype {}; using default fiber input loss'.format(objtype)
-            msg += '\nKnown objtypes are '+str(self._fiberinput.keys())
+            msg += '\nKnown objtypes are '+str(list(self._fiberinput.keys()))
             warnings.warn(msg)
             t = self._fiberinput['default']
 
@@ -303,7 +306,7 @@ class Throughput:
                 flux = flux * scale
                 units = tmp[1]
             except ValueError:
-                raise ValueError, "Non-numeric units scale factor " + tmp[0]
+                raise ValueError("Non-numeric units scale factor {}".format(tmp[0]))
 
         #- Default exposure time
         if exptime is None:
@@ -317,7 +320,7 @@ class Throughput:
 
         #- Sanity check on units
         if not units.startswith('erg'):
-            raise ValueError, "Unrecognized units " + units
+            raise ValueError("Unrecognized units {}".format(units))
 
         #- If we got here, we need to apply throughputs
         flux = self.apply_throughput(wavelength, flux,
@@ -343,7 +346,7 @@ class Throughput:
             return phot * exptime * self.area * self.fiberarea
 
         else:
-            raise ValueError, "Unrecognized units " + units
+            raise ValueError("Unrecognized units {}".format(units))
 
     def apply_throughput(self, wavelength, flux, objtype="STAR", airmass=1.0):
         """

--- a/py/specter/util/__init__.py
+++ b/py/specter/util/__init__.py
@@ -2,7 +2,7 @@
 specter.util
 ============
 """
-from __future__ import absolute_import, division, print_function
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 #- This polutes the namespace with other things like N, spdiags, ...
 from .util import *

--- a/py/specter/util/__init__.py
+++ b/py/specter/util/__init__.py
@@ -2,7 +2,9 @@
 specter.util
 ============
 """
+from __future__ import absolute_import, division, print_function
+
 #- This polutes the namespace with other things like N, spdiags, ...
-from util import *
-from traceset import TraceSet
-from cachedict import CacheDict
+from .util import *
+from .traceset import TraceSet
+from .cachedict import CacheDict

--- a/py/specter/util/pixspline.py
+++ b/py/specter/util/pixspline.py
@@ -2,6 +2,8 @@
 # Pixel-integrated sline utilities.
 # Written by A. Bolton, U. of Utah, 2010-2013.
 
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 import numbers
 import numpy as np
 from scipy import linalg as la

--- a/py/specter/util/pixspline.py
+++ b/py/specter/util/pixspline.py
@@ -2,6 +2,7 @@
 # Pixel-integrated sline utilities.
 # Written by A. Bolton, U. of Utah, 2010-2013.
 
+import numbers
 import numpy as np
 from scipy import linalg as la
 from scipy import sparse as sp
@@ -153,7 +154,7 @@ class PixelSpline:
         Also see: PixelSpline.resample()
         """
         input_scalar = False
-        if isinstance(xnew, float) or isinstance(xnew, int):
+        if isinstance(xnew, numbers.Real):
             input_scalar = True
             xnew = np.array( (xnew,) )
         

--- a/py/specter/util/traceset.py
+++ b/py/specter/util/traceset.py
@@ -6,6 +6,7 @@ import sys
 import os
 import numpy as np
 from numpy.polynomial.legendre import legfit, legval
+import numbers
 
 class TraceSet(object):
     def __init__(self, coeff, domain=[-1,1]):
@@ -22,19 +23,19 @@ class TraceSet(object):
         return self._coeff.shape[0]
         
     def _xnorm(self, x):
-        if not isinstance(x, (int,float,np.ndarray)):
+        if not isinstance(x, (numbers.Real, np.ndarray)):
             x = np.array(x)
         return 2.0 * (x - self._xmin) / (self._xmax - self._xmin) - 1.0
         
     def eval(self, ispec, x):
         xx = self._xnorm(x)
         
-        if isinstance(ispec, int):
+        if isinstance(ispec, numbers.Integral):
             return legval(xx, self._coeff[ispec])
         else:
             if ispec is None:
-                ispec = range(self._coeff.shape[0])
-            
+                ispec = list(range(self._coeff.shape[0]))
+
             y = [legval(xx, self._coeff[i]) for i in ispec]
             return np.array(y)
             

--- a/py/specter/util/traceset.py
+++ b/py/specter/util/traceset.py
@@ -2,6 +2,8 @@
 Handle sets of Legendre coefficients
 """
 
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 import sys
 import os
 import numpy as np

--- a/py/specter/util/util.py
+++ b/py/specter/util/util.py
@@ -180,7 +180,7 @@ def _sincfunc(x, dx, dampfac=3.25):
         return np.exp( -(xx/(dampfac*np.pi))**2 ) * np.sin(xx) / xx
     else:
         xx = np.zeros(len(x))
-        xx[len(x)/2] = 1.0
+        xx[len(x)//2] = 1.0
         return xx
 
 #- Implementation note: the typical PSF image is 15x15.

--- a/py/specter/util/util.py
+++ b/py/specter/util/util.py
@@ -5,6 +5,8 @@ Stephen Bailey
 Fall 2012
 """
 
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 import math
 import numpy as np
 import scipy.signal


### PR DESCRIPTION
This PR makes a bunch of little changes for python3 compatibility.  The code works for both python 2.7 and 3.5, so I'll try to support both for now, though python 2.7 support could be dropped without warning if some incompatibility arises.  I think I've configured Travis to test both as well.

A few notes:
* in a few test scripts, I chose to do an absolute `import specter.blah` import instead of a relative `import ..blah` so that the test script could be run by itself for faster focused testing of just that single piece.
* test_binscripts.py is the only place that needed a special case for python 2.7 vs. 3.5 for the logic of where the script is for when it is run; this was needed for finding the bin scripts to test them without installing them first.  This is handled as a special case, and is the only 2.7 vs. 3.5 special case needed here.
* most bugs that were not caught by 2to3 were related to integer vs. float division // vs. /
* the other tricky one was `isinstance(np.int64(1), int)` is True in python 2.7 and False in python 3.5; this was fixed using `isinstance(np.int64(1), numbers.Integral)` instead which is True for both python 2.7 and 3.5.
