### PR TITLE
index fix for small PSFs

### DIFF
--- a/py/specter/extract/ex2d.py
+++ b/py/specter/extract/ex2d.py
@@ -111,8 +111,8 @@ def ex2d(image, imageivar, psf, specmin, nspec, wavelengths, xyrange=None,
             ymin = ylo-ny+2
             ymax = yhi+ny-2
         
-            nlo = int((wlo - psf.wavelength(speclo, ymin))/dw)-1
-            nhi = int((psf.wavelength(speclo, ymax) - whi)/dw)-1
+            nlo = max(int((wlo - psf.wavelength(speclo, ymin))/dw)-1, ndiag)
+            nhi = max(int((psf.wavelength(speclo, ymax) - whi)/dw)-1, ndiag)
             ww = np.arange(wlo-nlo*dw, whi+(nhi+0.5)*dw, dw)
             wmin, wmax = ww[0], ww[-1]
             nw = len(ww)


### PR DESCRIPTION
This PR fixes #44 (Bug in ex2d when filling diagonals of resolution matrix).  The problem comes up when the PSF is small compared to the extraction wavelength step size.  The fix ensures the the number of border pixels for the divide-and-conquer extractions is at least large enough to include the number of needed off-diagonal elements of the resolution matrix.

NOTE: plotting the PSF from this example shows that the returned spot size (8x8) is way too small for the actual size the PSF.  Perhaps ok for fast debugging, but not good for detailed work.

This example also gives a warning that the frame is likely written without sufficient fiber information since it isn't including a fibermap.  The extraction does include a list of fibers when creating the Frame, so that warning may be bogus.  It should still be fixed in desispec, but that is separate from this specter bug.