### PR TITLE
gracefully handle nsubbundles>bundlesize

### DIFF
--- a/doc/release_notes.rst
+++ b/doc/release_notes.rst
@@ -5,7 +5,7 @@ specter Release Notes
 0.8.1 (unreleased)
 ------------------
 
-* No changes yet.
+* Robust even if nsubbundles>bundlesize.
 
 0.8.0 (2017-09-29)
 ------------------

--- a/py/specter/extract/ex2d.py
+++ b/py/specter/extract/ex2d.py
@@ -87,9 +87,10 @@ def ex2d(image, imageivar, psf, specmin, nspec, wavelengths, xyrange=None,
         #- index of last spectrum, non-inclusive, i.e. python-style indexing
         bundlehi = min(bundlelo+bundlesize, specmin+nspec)
 
-        iibundle, iiextract = split_bundle(bundlehi-bundlelo, nsubbundles)
+        nsub = min(bundlehi-bundlelo, nsubbundles)
+        iibundle, iiextract = split_bundle(bundlehi-bundlelo, nsub)
 
-        for subbundle_index in range(nsubbundles):
+        for subbundle_index in range(len(iiextract)):
             speclo = bundlelo + iiextract[subbundle_index][0]
             spechi = bundlelo + iiextract[subbundle_index][-1]+1
             keep = np.in1d(iiextract[subbundle_index], iibundle[subbundle_index])
@@ -499,6 +500,10 @@ def split_bundle(bundlesize, n):
     ([array([0, 1, 2]), array([3, 4, 5]), array([6, 7, 8, 9])],
      [array([0, 1, 2, 3]), array([2, 3, 4, 5, 6]), array([5, 6, 7, 8, 9])])
     '''
+    if n > bundlesize:
+        raise ValueError('n={} should be less or equal to bundlesize={}'.format(
+                         n, bundlesize))
+
     #- initial partition into subbundles
     n_per_subbundle = [len(x) for x in np.array_split(np.arange(bundlesize), n)]
 

--- a/py/specter/test/test_extract.py
+++ b/py/specter/test/test_extract.py
@@ -268,9 +268,11 @@ class TestExtract(unittest.TestCase):
         self.assertTrue( np.all(flux == flux) )
 
     def test_subbundles(self):
-        for nsubbundles in (2,3):
-            flux, ivar, Rdata = ex2d(self.image, self.ivar, self.psf, 0, self.nspec,
-                self.ww, wavesize=len(self.ww)//5, nsubbundles=nsubbundles)
+        #- should work even if nsubbundles > bundlesize
+        for nsubbundles in (2,3, 2*self.nspec):
+            flux, ivar, Rdata = ex2d(self.image, self.ivar, self.psf, 0,
+                self.nspec, self.ww, wavesize=len(self.ww)//5,
+                bundlesize=self.nspec, nsubbundles=nsubbundles)
 
             self.assertEqual(flux.shape, (self.nspec, len(self.ww)))
             self.assertEqual(ivar.shape, (self.nspec, len(self.ww)))
@@ -296,6 +298,10 @@ class TestExtract(unittest.TestCase):
         self.assertEqual(len(iiextract), 1)
         self.assertEqual(len(iisub[0]), 25)
         self.assertTrue(np.all(iisub[0] == iiextract[0]))
+
+        #- n>bundlesize isn't allowed
+        with self.assertRaises(ValueError):
+            iisub, iiextract = split_bundle(3, 7)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This PR gracefully handles the anomalous extraction case of nsubbundles>bundlesize.  Normally we wouldn't encounter this, but I hit this case with new desispec default of nsubbundles=7 but tests with only 3 spectra.