### PR TITLE
faster version of np.outer

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,7 +5,7 @@ specter change log
 0.8.4 (unreleased)
 ------------------
 
-* No changes yet.
+* np.outer replacement for 6% faster runtime (PR #58)
 
 0.8.3 (2018-02-23)
 ------------------

--- a/py/specter/psf/gausshermite.py
+++ b/py/specter/psf/gausshermite.py
@@ -16,7 +16,7 @@ from scipy import special as sp
 
 from astropy.io import fits
 from specter.psf import PSF
-from specter.util import TraceSet
+from specter.util import TraceSet, outer
 
 class GaussHermitePSF(PSF):
     """
@@ -197,10 +197,11 @@ class GaussHermitePSF(PSF):
         
         #- Create core PSF image
         core1 = np.zeros((ny, nx))
+        spot1 = np.empty_like(core1)
         for i in range(degx1+1):
             for j in range(degy1+1):
                 c1 = self.coeff['GH-{}-{}'.format(i,j)].eval(ispec, wavelength)
-                spot1 = np.outer(yfunc1[j], xfunc1[i])
+                outer(yfunc1[j], xfunc1[i], out=spot1)
                 core1 += c1 * spot1
         
         #- Zero out elements in the core beyond 3 sigma
@@ -217,7 +218,7 @@ class GaussHermitePSF(PSF):
         # core2 = np.zeros((ny, nx))
         # for i in range(degx2+1):
         #     for j in range(degy2+1):
-        #         spot2 = np.outer(yfunc2[j], xfunc2[i])
+        #         spot2 = outer(yfunc2[j], xfunc2[i])
         #         c2 = self.coeff['GH2-{}-{}'.format(i,j)].eval(ispec, wavelength)
         #         core2 += c2 * spot2
 

--- a/py/specter/psf/gausshermite2.py
+++ b/py/specter/psf/gausshermite2.py
@@ -19,7 +19,7 @@ from scipy import special as sp
 
 from astropy.io import fits
 from specter.psf import PSF
-from specter.util import TraceSet
+from specter.util import TraceSet, outer
 
 class GaussHermite2PSF(PSF):
     """
@@ -173,10 +173,11 @@ class GaussHermite2PSF(PSF):
         
         #- Create core PSF image
         core1 = np.zeros((ny, nx))
+        spot1 = np.empty_like(core1)
         for i in range(degx1+1):
             for j in range(degy1+1):
                 c1 = self.coeff['GH-{}-{}'.format(i,j)].eval(ispec, wavelength)
-                spot1 = np.outer(yfunc1[j], xfunc1[i])
+                outer(yfunc1[j], xfunc1[i], out=spot1)
                 core1 += c1 * spot1
         
         #- Zero out elements in the core beyond 3 sigma
@@ -190,9 +191,10 @@ class GaussHermite2PSF(PSF):
         xfunc2 = [self._pgh(xccd, i, x, sigma=sigx2) for i in range(degx2+1)]
         yfunc2 = [self._pgh(yccd, i, y, sigma=sigy2) for i in range(degy2+1)]
         core2 = np.zeros((ny, nx))
+        spot2 = np.empty_like(core2)
         for i in range(degx2+1):
             for j in range(degy2+1):
-                spot2 = np.outer(yfunc2[j], xfunc2[i])
+                outer(yfunc2[j], xfunc2[i], out=spot2)
                 c2 = self.coeff['GH2-{}-{}'.format(i,j)].eval(ispec, wavelength)
                 core2 += c2 * spot2
 

--- a/py/specter/test/test_extract.py
+++ b/py/specter/test/test_extract.py
@@ -13,7 +13,7 @@ import scipy.linalg
 import unittest
 from pkg_resources import resource_filename
 from specter.psf import load_psf
-from specter.extract.ex2d import ex2d, ex2d_patch, eigen_compose, split_bundle
+from specter.extract.ex2d import ex2d, ex2d_patch, eigen_compose, split_bundle, psfbias, psfabsbias
 from specter.extract.ex1d import ex1d
 
 class TestExtract(unittest.TestCase):
@@ -302,6 +302,16 @@ class TestExtract(unittest.TestCase):
         #- n>bundlesize isn't allowed
         with self.assertRaises(ValueError):
             iisub, iiextract = split_bundle(3, 7)
+
+    def test_psfbias(self):
+        psf = load_psf(resource_filename('specter.test', "t/psf-pix.fits"))
+        wmid = 0.5*(psf.wmin+psf.wmax)
+        ww = np.linspace(wmid-10, wmid+10)
+        phot = np.ones(len(ww))
+        phot[10] = 20
+        bias = psfbias(psf, psf, ww, phot)
+        absbias, R = psfabsbias(psf, psf, ww, phot)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/py/specter/test/test_util.py
+++ b/py/specter/test/test_util.py
@@ -63,15 +63,6 @@ class TestUtil(unittest.TestCase):
         self.assertEqual(a.shape, util.sincshift2d(a, 0.0, 0.1).shape)
         self.assertEqual(a.shape, util.sincshift2d(a, 0.1, 0.1).shape)
 
-    def test_psfbias(self):
-        psf = load_psf(resource_filename('specter.test', "t/psf-pix.fits"))
-        wmid = 0.5*(psf.wmin+psf.wmax)
-        ww = np.linspace(wmid-10, wmid+10)
-        phot = np.ones(len(ww))
-        phot[10] = 20
-        bias = util.psfbias(psf, psf, ww, phot)
-        absbias, R = util.psfabsbias(psf, psf, ww, phot)
-
     def test_resample(self):
         '''test resample; coverage only (not actual functionality)'''
         x = np.linspace(0, 2*np.pi, 20)
@@ -86,6 +77,15 @@ class TestUtil(unittest.TestCase):
         dt = util.util._timeit()
         self.assertGreater(dt, 0.1)
         self.assertLess(dt, 0.11)
+
+    def test_outer(self):
+        x = np.linspace(0, 2*np.pi, 20)
+        y = np.sin(x) + 1
+        out1 = np.empty((len(x), len(x)), dtype=float)
+        out2 = np.empty_like(out1)
+        np.outer(x, y, out=out1)
+        util.outer(x, y, out=out2)
+        self.assertTrue(np.all(out1==out2))
 
     # def test_rebin(self):
     #     x = np.arange(25)


### PR DESCRIPTION
This version provides a faster version of `numpy.outer`, which was taking a non-trivial amount of extraction processing time.  It either uses numba (~3x faster) or if numba isn't installed, it bypasses the numpy type and dimensionality checks to be ~1.5x faster.  The overall impact is modest: 6% faster runtimes for a full frame, but that still corresponds to O(5M) NERSC MPP hours saved over the lifetime of DESI.

A knock-on effect was that the `psfbias` and `psfabsbias` functions moved from `specter.util` to `specter.extract` to avoid a circular dependency.

I tested that this code is faster and produces bitwise identical results (except for the timestamps in the fits headers).