### PR TITLE
Legval speedup

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,7 +5,7 @@ specter change log
 0.8.6 (unreleased)
 ------------------
 
-* No changes yet.
+* Added numba-ized legval for ~20% overall ex2d speedup (PR #61).
 
 0.8.5 (2018-05-10)
 ------------------

--- a/py/specter/test/test_util.py
+++ b/py/specter/test/test_util.py
@@ -11,6 +11,7 @@ import os
 import numpy as np
 from numpy.polynomial import legendre
 from specter import util
+from specter.util import legval_numba
 import unittest
 from pkg_resources import resource_filename
 from specter.psf import load_psf
@@ -86,6 +87,33 @@ class TestUtil(unittest.TestCase):
         np.outer(x, y, out=out1)
         util.outer(x, y, out=out2)
         self.assertTrue(np.all(out1==out2))
+
+    def test_legval_numba(self):
+        #test both x scalars and x arrays of various sizes
+        #c will always be an array with len(c) > 2
+        x_scalar_1=np.random.rand(1)
+        x_scalar_2=np.random.rand(1)
+        x_array_1=np.random.rand(1000)
+        x_array_2=np.random.rand(500)
+        c_array_1=np.random.rand(8)
+        c_array_2=np.random.rand(11)
+       
+        #make sure legval_numba gets the same answer as numpy legval
+        #first test x scalars
+        numba_return_scalar_1 = legval_numba(x_scalar_1, c_array_1)
+        legval_return_scalar_1 = np.polynomial.legendre.legval(x_scalar_1, c_array_1)
+        numba_return_scalar_2 = legval_numba(x_scalar_2, c_array_2)
+        legval_return_scalar_2 = np.polynomial.legendre.legval(x_scalar_2, c_array_2)
+        self.assertTrue(np.allclose(numba_return_scalar_1, legval_return_scalar_1))
+        self.assertTrue(np.allclose(numba_return_scalar_2, legval_return_scalar_2))
+
+        #then test x arrays
+        numba_return_array_1 = legval_numba(x_array_1, c_array_1)
+        legval_return_array_1 = np.polynomial.legendre.legval(x_array_1, c_array_1)
+        numba_return_array_2 = legval_numba(x_array_2, c_array_2)
+        legval_return_array_2 = np.polynomial.legendre.legval(x_array_2, c_array_2)
+        self.assertTrue(np.allclose(numba_return_array_1, legval_return_array_1))
+        self.assertTrue(np.allclose(numba_return_array_2, legval_return_array_2))
 
     # def test_rebin(self):
     #     x = np.arange(25)

--- a/py/specter/util/util.py
+++ b/py/specter/util/util.py
@@ -226,9 +226,8 @@ except ImportError:
         return np.multiply(x[:, None], y[None, :], out)
     
 
-#have faster numba version of legval if numba is available
+# have faster numba version of legval if numba is available
 try:
-    #this is the faster, flexible, most readable version
     if 'NUMBA_DISABLE_JIT' in os.environ:
         raise ImportError
     import numba
@@ -248,38 +247,9 @@ try:
         return c0 + c1*x
 
 except ImportError:
-    #in the event there is no numba, revert to the orig legval
-    #this is an exact copy of numpy's legval
-    def legval_numba(x, c, tensor=True):
-        c = np.array(c, ndmin=1, copy=0)
-        if c.dtype.char in '?bBhHiIlLqQpP':
-            c = c.astype(np.double)
-        if isinstance(x, (tuple, list)):
-            x = np.asarray(x)
-        if isinstance(x, np.ndarray) and tensor:
-            c = c.reshape(c.shape + (1,)*x.ndim)
-
-        if len(c) == 1:
-            c0 = c[0]
-            c1 = 0
-        elif len(c) == 2:
-            c0 = c[0]
-            c1 = c[1]
-        else:
-            nd = len(c)
-            c0 = c[-2]
-            c1 = c[-1]
-            for i in range(3, len(c) + 1):
-                tmp = c0
-                nd = nd - 1
-                c0 = c[-i] - (c1*(nd - 1))/nd
-                c1 = tmp + (c1*x*(2*nd - 1))/nd
-        return c0 + c1*x
-    
-    
-    
-    
-    
+    # in the event there is no numba, revert to the orig legval while
+    # still calling it legval_numba so that they can be used interchangeably
+    from numpy.polynomial.legendre import legval as legval_numba
     
     
     


### PR DESCRIPTION
This pull request adds an optional numba-ized version of legval (one of the most important kernels in the code). For a test case of desi_extract_spectra this results in about a 20 percent overall speedup on KNL and Haswell. If numba is not present, the code will fall back to the original numpy legval. 