### PR TITLE
fix legval_numba scalar vs. vectors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -79,7 +79,7 @@ matrix:
         #        PIP_DEPENDENCIES=$PIP_ALL_DEPENDENCIES
 
         - os: linux
-          env: PYTHON_VERSION=3.5 MAIN_CMD='python'
+          env: PYTHON_VERSION=3.5
                SETUP_CMD="test"
                CONDA_DEPENDENCIES=$CONDA_ALL_DEPENDENCIES
                PIP_DEPENDENCIES=$PIP_ALL_DEPENDENCIES

--- a/.travis.yml
+++ b/.travis.yml
@@ -72,15 +72,15 @@ matrix:
           # -w is an astropy extension
 
         # Try 2.7 and 3.5 python versions with the latest numpy
-        - os: linux
-          env: PYTHON_VERSION=2.7 MAIN_CMD='coverage'
-               SETUP_CMD="run py/specter/test/specter_test_suite.py"
-               CONDA_DEPENDENCIES=$CONDA_ALL_DEPENDENCIES
-               PIP_DEPENDENCIES=$PIP_ALL_DEPENDENCIES
+        # - os: linux
+        #   env: PYTHON_VERSION=2.7 MAIN_CMD='coverage'
+        #        SETUP_CMD="run py/specter/test/specter_test_suite.py"
+        #        CONDA_DEPENDENCIES=$CONDA_ALL_DEPENDENCIES
+        #        PIP_DEPENDENCIES=$PIP_ALL_DEPENDENCIES
 
         - os: linux
           env: PYTHON_VERSION=3.5 MAIN_CMD='python'
-               SETUP_CMD="py/specter/test/specter_test_suite.py"
+               SETUP_CMD="test"
                CONDA_DEPENDENCIES=$CONDA_ALL_DEPENDENCIES
                PIP_DEPENDENCIES=$PIP_ALL_DEPENDENCIES
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,12 +40,12 @@ env:
         # to repeat them for all configurations.
         # - NUMPY_VERSION=1.10
         # - SCIPY_VERSION=0.17
-        - ASTROPY_VERSION=1.1.1
+        - ASTROPY_VERSION=2
         - MAIN_CMD='python setup.py'
         # These packages will always be installed.
         - CONDA_DEPENDENCIES=''
         # These packages will only be installed if we really need them.
-        - CONDA_ALL_DEPENDENCIES='scipy coverage==3.7.1 requests'
+        - CONDA_ALL_DEPENDENCIES='scipy coverage==3.7.1 requests numba'
         # These packages will always be installed.
         - PIP_DEPENDENCIES=''
         # These packages will only be installed if we really need them.

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -6,6 +6,7 @@ specter change log
 ------------------
 
 * Added numba-ized legval for ~20% overall ex2d speedup (PR #61).
+* Fixed tests (PR #62).
 
 0.8.5 (2018-05-10)
 ------------------

--- a/py/specter/psf/psf.py
+++ b/py/specter/psf/psf.py
@@ -60,12 +60,15 @@ class PSF(object):
             self.psferr = hdr['PSFERR']
         else:
             self.psferr = 0.01
-        
+
         #- Load x, y legendre coefficient tracesets
-        xc, hdr = fits.getdata(filename, 'XCOEFF', header=True)
-        self._x = TraceSet(xc, domain=(hdr['WAVEMIN'], hdr['WAVEMAX']))
-        yc, hdr = fits.getdata(filename, 'YCOEFF', header=True)
-        self._y = TraceSet(yc, domain=(hdr['WAVEMIN'], hdr['WAVEMAX']))
+        with fits.open(filename) as fx:
+            xc = fx['XCOEFF'].data
+            hdr = fx['XCOEFF'].header
+            self._x = TraceSet(xc, domain=(hdr['WAVEMIN'], hdr['WAVEMAX']))
+            yc = fx['YCOEFF'].data
+            hdr = fx['YCOEFF'].header
+            self._y = TraceSet(yc, domain=(hdr['WAVEMIN'], hdr['WAVEMAX']))
         
         #- Create inverse y -> wavelength mapping
         self._w = self._y.invert()

--- a/py/specter/psf/spotgrid.py
+++ b/py/specter/psf/spotgrid.py
@@ -15,7 +15,6 @@ from astropy.io import fits
 from specter.psf import PSF
 from specter.util import LinearInterp2D, rebin_image, sincshift
 import scipy.interpolate
-import numba
 
 class SpotGridPSF(PSF):
     """
@@ -133,7 +132,9 @@ class SpotGridPSF(PSF):
         return img.reshape(x.shape)
 
 
-@numba.jit(nopython=True,cache=True)
+import numba
+# @numba.jit(nopython=True,cache=True)
+@numba.jit
 def new_pixshift(xc,yc,pix_spot_values,rebin):
     """
     Inputs: xc, yc are center of the PSF in ccd coordinates

--- a/py/specter/psf/spotgrid.py
+++ b/py/specter/psf/spotgrid.py
@@ -10,6 +10,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import sys
 import os
+import math
 import numpy as np
 from astropy.io import fits
 from specter.psf import PSF
@@ -133,8 +134,8 @@ class SpotGridPSF(PSF):
 
 
 import numba
-# @numba.jit(nopython=True,cache=True)
-@numba.jit
+# @numba.jit
+@numba.jit(nopython=True,cache=False)
 def new_pixshift(xc,yc,pix_spot_values,rebin):
     """
     Inputs: xc, yc are center of the PSF in ccd coordinates
@@ -143,16 +144,16 @@ def new_pixshift(xc,yc,pix_spot_values,rebin):
     Outputs: resampled_pix_spot_values, the resampled and scaled 2D array of pix_spot_values
     """
     # fraction pixel offset requiring interpolation
-    shiftx=xc*rebin-int(np.floor(xc*rebin)) # positive value between 0 and 1
-    shifty=yc*rebin-int(np.floor(yc*rebin)) # positive value between 0 and 1
+    shiftx=xc*rebin-int(math.floor(xc*rebin)) # positive value between 0 and 1
+    shifty=yc*rebin-int(math.floor(yc*rebin)) # positive value between 0 and 1
     # weights for interpolation
     w00=(1-shifty)*(1-shiftx)
     w10=shifty*(1-shiftx)
     w01=(1-shifty)*shiftx
     w11=shifty*shiftx        
     # now the rest of the offset is an integer shift
-    dx=int(np.floor(xc*rebin))-int(np.floor(xc))*rebin # positive integer between 0 and 14
-    dy=int(np.floor(yc*rebin))-int(np.floor(yc))*rebin # positive integer between 0 and 14
+    dx=int(np.floor(xc*rebin))-int(math.floor(xc))*rebin # positive integer between 0 and 14
+    dy=int(np.floor(yc*rebin))-int(math.floor(yc))*rebin # positive integer between 0 and 14
     ny_spot, nx_spot = pix_spot_values.shape
     #preallocate 
     resampled_pix_spot_values=np.zeros((ny_spot+rebin,nx_spot+rebin))

--- a/py/specter/psf/spotgrid.py
+++ b/py/specter/psf/spotgrid.py
@@ -134,7 +134,6 @@ class SpotGridPSF(PSF):
 
 
 import numba
-# @numba.jit
 @numba.jit(nopython=True,cache=False)
 def new_pixshift(xc,yc,pix_spot_values,rebin):
     """

--- a/py/specter/test/test_psf.py
+++ b/py/specter/test/test_psf.py
@@ -551,12 +551,12 @@ class TestGaussHermite2PSF(GenericPSFTests,unittest.TestCase):
         cls.psf = load_psf(resource_filename("specter.test", "t/psf-gausshermite2.fits"))
 
 if __name__ == '__main__':
-    # unittest.main()
-    s1 = unittest.defaultTestLoader.loadTestsFromTestCase(TestPixPSF)
-    s2 = unittest.defaultTestLoader.loadTestsFromTestCase(TestSpotPSF)
-    s3 = unittest.defaultTestLoader.loadTestsFromTestCase(TestMonoSpotPSF)
-    s4 = unittest.defaultTestLoader.loadTestsFromTestCase(TestGaussHermitePSF)
-    s5 = unittest.defaultTestLoader.loadTestsFromTestCase(TestGaussHermite2PSF)
+    testLoader = unittest.defaultTestLoader.loadTestsFromTestCase  #- shorthand
+    psftests = list()
+    # psftests.append( testLoader(TestPixPSF) )
+    psftests.append( testLoader(TestSpotPSF) )
+    # psftests.append( testLoader(TestMonoSpotPSF) )
+    # psftests.append( testLoader(TestGaussHermitePSF) )
+    # psftests.append( testLoader(TestGaussHermite2PSF) )
 
-    unittest.TextTestRunner(verbosity=2).run(unittest.TestSuite([s1, s2, s3, s4, s5]))
-    # unittest.TextTestRunner(verbosity=2).run(unittest.TestSuite([s2,]))
+    unittest.TextTestRunner(verbosity=2).run(unittest.TestSuite(psftests))

--- a/py/specter/test/test_psf.py
+++ b/py/specter/test/test_psf.py
@@ -454,7 +454,7 @@ class GenericPSFTests(object):
         self.assertLess(psf.wmin, psf.wmax)
 
     #- Test getting x and y and wavelength at the same time
-    ### REMOVED
+    ### REMOVED; (why?)
     # def test_xyw(self):
     #     x = self.psf.x(0)
     #     y = self.psf.y(0)
@@ -553,10 +553,10 @@ class TestGaussHermite2PSF(GenericPSFTests,unittest.TestCase):
 if __name__ == '__main__':
     testLoader = unittest.defaultTestLoader.loadTestsFromTestCase  #- shorthand
     psftests = list()
-    # psftests.append( testLoader(TestPixPSF) )
+    psftests.append( testLoader(TestPixPSF) )
     psftests.append( testLoader(TestSpotPSF) )
-    # psftests.append( testLoader(TestMonoSpotPSF) )
-    # psftests.append( testLoader(TestGaussHermitePSF) )
-    # psftests.append( testLoader(TestGaussHermite2PSF) )
+    psftests.append( testLoader(TestMonoSpotPSF) )
+    psftests.append( testLoader(TestGaussHermitePSF) )
+    psftests.append( testLoader(TestGaussHermite2PSF) )
 
     unittest.TextTestRunner(verbosity=2).run(unittest.TestSuite(psftests))

--- a/py/specter/test/test_psf.py
+++ b/py/specter/test/test_psf.py
@@ -126,8 +126,8 @@ class GenericPSFTests(object):
     #- Test that PSF spots are positive
     def test_pix_norm(self):
         psf = self.psf
-        yy = np.arange(50, psf.npix_y-50, 50)  #- keep away from the edges
-        for i in range(0, psf.nspec, 1+psf.nspec//10):
+        yy = np.arange(50, psf.npix_y-50, 500)  #- keep away from the edges
+        for i in range(0, psf.nspec, 1+psf.nspec//50):
             ww = psf.wavelength(i, yy)
             for w in ww:
                 self.assertTrue(np.all(psf.pix(i, w) >= 0), \
@@ -282,7 +282,7 @@ class GenericPSFTests(object):
     #- Test projection with an xyrange that is smaller than wavelength range
     def test_project_small_xyrange(self):
         #- Find the xyrange for a small range of wavelengths
-        nspec = 5
+        nspec = 3
         nw = 5
         ww = self.psf.wavelength(0)[1000:1000+nw]
         spec_range = (0, nspec)
@@ -298,8 +298,8 @@ class GenericPSFTests(object):
 
     #- Test the projection matrix gives same answer as psf.project()
     def test_projection_matrix(self):
-        nspec = 5
-        nw = 20
+        nspec = 3
+        nw = 5
         w_edge = 10  #- avoid edge effects; test that separately
         phot = np.random.uniform(100,1000, size=(nspec, nw))
         for specmin in (0, self.psf.nspec//2, self.psf.nspec-nspec-1):
@@ -551,10 +551,6 @@ class TestGaussHermite2PSF(GenericPSFTests,unittest.TestCase):
         cls.psf = load_psf(resource_filename("specter.test", "t/psf-gausshermite2.fits"))
 
 if __name__ == '__main__':
-
-    import warnings
-    warnings.simplefilter('error')
-
     # unittest.main()
     s1 = unittest.defaultTestLoader.loadTestsFromTestCase(TestPixPSF)
     s2 = unittest.defaultTestLoader.loadTestsFromTestCase(TestSpotPSF)

--- a/py/specter/test/test_util.py
+++ b/py/specter/test/test_util.py
@@ -115,6 +115,31 @@ class TestUtil(unittest.TestCase):
         self.assertTrue(np.allclose(numba_return_array_1, legval_return_array_1))
         self.assertTrue(np.allclose(numba_return_array_2, legval_return_array_2))
 
+    def test_traceset(self):
+        nspec = 3
+        nx = 10
+        iispec = np.arange(nspec)
+        x = 100 + 0.2*np.arange(nx)
+        yy = np.random.normal(size=(nspec, nx))
+
+        tx = util.traceset.fit_traces(x, yy)
+        tinv = tx.invert()
+
+        y = tx.eval(0, x[0])
+        self.assertTrue(isinstance(y, float))
+
+        y = tx.eval(0, x)
+        self.assertTrue(isinstance(y, np.ndarray))
+        self.assertEqual(y.shape, (nx,))
+
+        y = tx.eval(iispec, x[0])
+        self.assertTrue(isinstance(y, np.ndarray))
+        self.assertEqual(y.shape, (nspec,))
+
+        y = tx.eval(iispec, x)
+        self.assertTrue(isinstance(y, np.ndarray))
+        self.assertEqual(y.shape, (nspec, nx))
+
     # def test_rebin(self):
     #     x = np.arange(25)
     #     y = np.random.uniform(0.0, 5.0, size=len(x))

--- a/py/specter/util/traceset.py
+++ b/py/specter/util/traceset.py
@@ -32,13 +32,18 @@ class TraceSet(object):
         
     def eval(self, ispec, x):
         xx = np.array(self._xnorm(x))
+        scalar_input = np.isscalar(x)
    
         #numba requires f8 or smaller
         cc_numba = self._coeff[ispec].astype(np.float64, copy=False)
 
         #use numba version of legval if possible
         if isinstance(ispec, numbers.Integral):
-            return legval_numba(xx, cc_numba)
+            results = legval_numba(xx, cc_numba)
+            if scalar_input:
+                return results[0]
+            else:
+                return results
         else:
             if ispec is None:
                 ispec = list(range(self._coeff.shape[0]))
@@ -47,7 +52,11 @@ class TraceSet(object):
             y=[]
             for i in ispec:
                 cc_i = self._coeff[i].astype(np.float64, copy=False)
-                y.append(legval_numba(xx, cc_i))
+                if scalar_input:
+                    y.append(legval_numba(xx, cc_i)[0])
+                else:
+                    y.append(legval_numba(xx, cc_i))
+
             return np.array(y)
             
     # def __call__(self, ispec, x):

--- a/py/specter/util/util.py
+++ b/py/specter/util/util.py
@@ -226,30 +226,20 @@ except ImportError:
         return np.multiply(x[:, None], y[None, :], out)
     
 
-# have faster numba version of legval if numba is available
-try:
-    if 'NUMBA_DISABLE_JIT' in os.environ:
-        raise ImportError
-    import numba
-    @numba.jit(nopython=True,cache=True)
-    def legval_numba(x, c):
-        nd=len(c)
-        ndd=nd
-        xlen = x.size
-        c0=c[-2]*np.ones(xlen)
-        c1=c[-1]*np.ones(xlen)
-        for i in range(3, ndd + 1):
-            tmp = c0
-            nd = nd - 1
-            nd_inv = 1/nd
-            c0 = c[-i] - (c1*(nd - 1))*nd_inv
-            c1 = tmp + (c1*x*(2*nd - 1))*nd_inv
-        return c0 + c1*x
-
-except ImportError:
-    # in the event there is no numba, revert to the orig legval while
-    # still calling it legval_numba so that they can be used interchangeably
-    from numpy.polynomial.legendre import legval as legval_numba
-    
-    
+# Much faster than numpy.polynomial.legendre.legval, but doesn't work with scalars
+import numba
+@numba.jit(nopython=True,cache=True)
+def legval_numba(x, c):
+    nd=len(c)
+    ndd=nd
+    xlen = x.size
+    c0=c[-2]*np.ones(xlen)
+    c1=c[-1]*np.ones(xlen)
+    for i in range(3, ndd + 1):
+        tmp = c0
+        nd = nd - 1
+        nd_inv = 1/nd
+        c0 = c[-i] - (c1*(nd - 1))*nd_inv
+        c1 = tmp + (c1*x*(2*nd - 1))*nd_inv
+    return c0 + c1*x
     


### PR DESCRIPTION
On both Cori and my laptop, I was getting numba errors on `specter.psf.spotgrid.new_pixshift`.  Using vanilla `@numpy.jit` works, but `@numba.jit(nopython=True, cache=True)` does not.  @lastephey is away this week so this is an emergency patch and I'll coordinate with her next week about testing nopython vs. not.

This is a schroedinbug: once observed it became reproducible, but I don't understand how it ever worked in the first place or how testing didn't catch it.  This code was introduced 5 months ago in PR #56 and tests apparently only started failing while I was on vacation last week.  The Travis tests were failing on "import numba" before ever running, which Travis incorrectly interpreted as success (!), but I don't understand how/why the nightly NERSC tests weren't catching this.

A few other changes came along for the ride:
* don't fail on warnings; this can be problematic with various combinations of scipy/numpy versions
* slightly more efficient XCOEFF/YCOEFF reading
* faster PSF tests by using fewer spectra and fewer wavelengths
* test against astropy=2 instead of 1.1.1