### PR TITLE
Lower regularization

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -7,6 +7,7 @@ specter change log
 
 * Added numba-ized legval for ~20% overall ex2d speedup (PR #61).
 * Fixed tests (PR #62).
+* Less regularization for ringing to lower bias (PR #63).
 
 0.8.5 (2018-05-10)
 ------------------


### PR DESCRIPTION
In ex2d a regularization term is added to the inverse covariance matrix. This regularization is needed to reduce a ringing in the extracted spectra due to a flux bias on the edge flux bins in the divide and conquer approach when the PSF is not perfect (the edge flux bins are constrained only by a few CCD pixels and the wings of the PSF). It is also needed when some spectral fluxes are unconstrained because of masked pixels. The drawback is that this is biasing at the high flux limit because bright pixels.
In this PR, the regularization threshold is lowered by a factor of 100. The min weight is set to 1e-4 of the max weight. This corresponds to the ratio of Poisson to read noise variance for a 1e5 pixel (CCD full well) and a 3e read noise.