### PR TITLE
don't use numba cache

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -6,6 +6,7 @@ specter change log
 ------------------
 
 * Add custom `xsigma` and `ysigma` functions to GaussHermitePSF (PR #66).
+* Don't use numba caching due to MPI race condition (PR #67).
 
 0.8.6 (2018-06-27)
 ------------------

--- a/py/specter/util/util.py
+++ b/py/specter/util/util.py
@@ -228,7 +228,7 @@ except ImportError:
 
 # Much faster than numpy.polynomial.legendre.legval, but doesn't work with scalars
 import numba
-@numba.jit(nopython=True,cache=True)
+@numba.jit(nopython=True,cache=False)
 def legval_numba(x, c):
     nd=len(c)
     ndd=nd


### PR DESCRIPTION
This PR fixes #65 by disabling numba caching due to a race condition in writing the cache when using MPI.  The performance hit of re-generating the numba compilation every time is minor compared to the overall runtime of extractions and pixsims.

Curiously, I was only able to reproduce the failure with *installed* versions of specter.  Simply having a bare clone in my $PYTHONPATH worked (though I couldn't find if/where it was writing the cache in that case).  I have confirmed that turning off that cache works with installed copies of specter (albeit with low-number-statistics on the runs).