### PR TITLE
Small speedups

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -7,6 +7,7 @@ specter change log
 
 * Add custom `xsigma` and `ysigma` functions to GaussHermitePSF (PR #66).
 * Don't use numba caching due to MPI race condition (PR #67).
+* Small speed improvements (PR #68).
 
 0.8.6 (2018-06-27)
 ------------------

--- a/py/specter/psf/gausshermite.py
+++ b/py/specter/psf/gausshermite.py
@@ -45,7 +45,7 @@ class GaussHermitePSF(PSF):
         else :
             psf_hdu = "PSF"
         
-        self._polyparams = hdr = fx[psf_hdu].header
+        self._polyparams = hdr = dict(fx[psf_hdu].header)
         if 'PSFTYPE' not in hdr:
             raise ValueError('Missing PSFTYPE keyword')
             
@@ -100,11 +100,15 @@ class GaussHermitePSF(PSF):
         
         #- Create inverse y -> wavelength mapping
         self._w = self._y.invert()
-        self._wmin = np.min(self.wavelength(None, 0))
-        self._wmin_all = np.max(self.wavelength(None, 0))
-        self._wmax = np.max(self.wavelength(None, self.npix_y-1))
-        self._wmax_all = np.min(self.wavelength(None, self.npix_y-1))
-               
+
+        #- Cache min/max wavelength per fiber at pixel edges
+        self._wmin_spec = self.wavelength(None, -0.5)
+        self._wmax_spec = self.wavelength(None, self.npix_y-0.5)
+        self._wmin = np.min(self._wmin_spec)
+        self._wmin_all = np.max(self._wmin_spec)
+        self._wmax = np.max(self._wmax_spec)
+        self._wmax_all = np.min(self._wmax_spec)
+
         #- Filled only if needed
         self._xsigma = None
         self._ysigma = None

--- a/py/specter/psf/gausshermite2.py
+++ b/py/specter/psf/gausshermite2.py
@@ -74,11 +74,15 @@ class GaussHermite2PSF(PSF):
 
         #- Create inverse y -> wavelength mapping
         self._w = self._y.invert()
-        self._wmin = np.min(self.wavelength(None, 0))
-        self._wmin_all = np.max(self.wavelength(None, 0))
-        self._wmax = np.max(self.wavelength(None, self.npix_y-1))
-        self._wmax_all = np.min(self.wavelength(None, self.npix_y-1))
-                
+
+        #- Cache min/max wavelength per fiber at pixel edges
+        self._wmin_spec = self.wavelength(None, -0.5)
+        self._wmax_spec = self.wavelength(None, self.npix_y-0.5)
+        self._wmin = np.min(self._wmin_spec)
+        self._wmin_all = np.max(self._wmin_spec)
+        self._wmax = np.max(self._wmax_spec)
+        self._wmax_all = np.min(self._wmax_spec)
+
         #- Filled only if needed
         self._xsigma = None
         self._ysigma = None


### PR DESCRIPTION
This PR includes simple three O(1%) speedups that I found while reviewing how `GaussHermitePSF._xypix` in search of larger speedups.
* Keep `self._polyparams` as a `dict` instead of an `astropy.fits.Header` for faster element lookups
* Cache the minimum and maximum wavelength per fiber so that it doesn't have to be recalculated for every call to `xypix` to see if we are off the edge of the CCD.
* In `PSF.projection_matrix`, fill a transposed version of `A` (faster) and then transpose it once at the end.
  * there are likely better ways than filling `A` and then converting to a csr sparse matrix.  This could be an area for future study.