### PR TITLE
Faster xnorm

### DIFF
--- a/py/specter/util/traceset.py
+++ b/py/specter/util/traceset.py
@@ -26,13 +26,7 @@ class TraceSet(object):
         return self._coeff.shape[0]
         
     def _xnorm(self, x):
-        #- Faster to rarely fail & convert than to check everytime
-        try:
-            return 2.0 * (x - self._xmin) / (self._xmax - self._xmin) - 1.0
-        except TypeError:
-            #- convert list or tuple to array
-            x = np.array(x)
-            return 2.0 * (x - self._xmin) / (self._xmax - self._xmin) - 1.0
+        return 2.0 * (x - self._xmin) / (self._xmax - self._xmin) - 1.0
         
     def eval(self, ispec, x):
         xx = np.array(self._xnorm(x))

--- a/py/specter/util/traceset.py
+++ b/py/specter/util/traceset.py
@@ -26,12 +26,11 @@ class TraceSet(object):
         return self._coeff.shape[0]
         
     def _xnorm(self, x):
-        # if not isinstance(x, (numbers.Real, np.ndarray)):
-        #     x = np.array(x)
         #- Faster to rarely fail & convert than to check everytime
         try:
             return 2.0 * (x - self._xmin) / (self._xmax - self._xmin) - 1.0
         except TypeError:
+            #- convert list or tuple to array
             x = np.array(x)
             return 2.0 * (x - self._xmin) / (self._xmax - self._xmin) - 1.0
         
@@ -71,7 +70,7 @@ class TraceSet(object):
         """
         Return a traceset modeling x vs. y instead of y vs. x
         """
-        ytmp = self.eval(None, (self._xmin, self._xmax))
+        ytmp = self.eval(None, np.array([self._xmin, self._xmax]))
         ymin = np.min(ytmp)
         ymax = np.max(ytmp)
         x = np.linspace(self._xmin, self._xmax, 1000)

--- a/py/specter/util/traceset.py
+++ b/py/specter/util/traceset.py
@@ -26,9 +26,14 @@ class TraceSet(object):
         return self._coeff.shape[0]
         
     def _xnorm(self, x):
-        if not isinstance(x, (numbers.Real, np.ndarray)):
+        # if not isinstance(x, (numbers.Real, np.ndarray)):
+        #     x = np.array(x)
+        #- Faster to rarely fail & convert than to check everytime
+        try:
+            return 2.0 * (x - self._xmin) / (self._xmax - self._xmin) - 1.0
+        except TypeError:
             x = np.array(x)
-        return 2.0 * (x - self._xmin) / (self._xmax - self._xmin) - 1.0
+            return 2.0 * (x - self._xmin) / (self._xmax - self._xmin) - 1.0
         
     def eval(self, ispec, x):
         xx = np.array(self._xnorm(x))


### PR DESCRIPTION
This PR provides another small speedup.  `TraceSet._xnorm(x)` now requires scalar or array input, but not list or tuple input.  There was only one place that was providing a list and it was easy to change that to an array, instead of having xnorm have to check every time it is called (which is many many times and adds up).

Note: I didn't want to use `np.asarray(x)` for the conversion because that also has to do checking and also changes the type when given a scalar input (true float -> 0-dim array of float).