### PR TITLE
Fix pgh

### DIFF
--- a/py/specter/psf/gausshermite.py
+++ b/py/specter/psf/gausshermite.py
@@ -16,7 +16,7 @@ from scipy import special as sp
 
 from astropy.io import fits
 from specter.psf import PSF
-from specter.util import TraceSet, outer, legval_numba
+from specter.util import TraceSet, outer, legval_numba, custom_hermitenorm, custom_erf
 
 import numba
 
@@ -406,123 +406,9 @@ def pgh(x, m=0, xc=0.0, sigma=1.0):
         return (y[1:] - y[0:-1])
     else:            
         y = custom_erf(u/np.sqrt(2.))
-        #y_old = sp.erf(u/np.sqrt(2.))
+        #y = sp.erf(u/np.sqrt(2.))
         return 0.5 * (y[1:] - y[0:-1])
 
-@numba.jit(nopython=True, cache=False)
-def custom_hermitenorm(n, u):
-    #below is (mostly) cut and paste from scipy orthogonal_eval.pxd
-    #some modifications have been made to operate on an array
-    #rather than a single value (as in the original version)
-    res=np.zeros(len(u))
-    if n < 0:
-        return (0.0)*np.ones(len(u))
-    elif n == 0:
-        return (1.0)*np.ones(len(u))
-    elif n == 1:
-        return u
-    else:
-        y3 = 0.0
-        y2 = 1.0
-        for i,x in enumerate(u):
-            for k in range(n, 1, -1):
-                y1 = x*y2-k*y3
-                y3 = y2
-                y2 = y1
-            res[i]=x*y2-y3
-            #have to reset before the next iteration
-            y3 = 0.0
-            y2 = 1.0
-        return res
-
-
-#going to re-implement the scipy erf.f fortran function 
-#in python so we can eventually jit-compile (which currently
-#does not support scipy)
-@numba.jit(nopython=True, cache=False)
-def custom_erf(y):
-    #have to define a ton of constants
-    c=0.564189583547756E0
-    ###
-    a1=.771058495001320E-04 
-    a2=-0.133733772997339E-02
-    a3=0.323076579225834E-01
-    a4=0.479137145607681E-01
-    a5=0.128379167095513E+00
-    ###
-    b1=0.301048631703895E-02
-    b2=0.538971687740286E-01
-    b3=0.375795757275549E+00
-    ###
-    p1=-1.36864857382717E-07
-    p2=5.64195517478974E-01
-    p3=7.21175825088309E+00
-    p4=4.31622272220567E+01
-    p5=1.52989285046940E+02
-    p6=3.39320816734344E+02
-    p7=4.51918953711873E+02
-    p8=3.00459261020162E+02
-    ###
-    q1=1.00000000000000E+00
-    q2=1.27827273196294E+01
-    q3=7.70001529352295E+01 
-    q4=2.77585444743988E+02 
-    q5=6.38980264465631E+02
-    q6=9.31354094850610E+02
-    q7=7.90950925327898E+02
-    q8=3.00459260956983E+02
-    ###
-    r1=2.10144126479064E+00
-    r2=2.62370141675169E+01
-    r3=2.13688200555087E+01
-    r4=4.65807828718470E+00
-    r5=2.82094791773523E-01
-    ###
-    s1=9.41537750555460E+01
-    s2=1.87114811799590E+02
-    s3=9.90191814623914E+01
-    s4=1.80124575948747E+01
-    ###
-    #end of constants
-
-    #the orig version is meant for a single point
-    #need to modify to work on an array
-    erf = np.zeros(len(y))
-    for i,x in enumerate(y):
-        ax=abs(x) 
-        #change gotos into something sensible
-        if ax <= 0.5E0:
-            t=x*x
-            top = ((((a1*t+a2)*t+a3)*t+a4)*t+a5) + 1.0E0
-            bot = ((b1*t+b2)*t+b3)*t + 1.0E0
-            erf[i] = x * (top/bot)
-        elif 0.5E0 < ax <= 4.0E0:
-            top = ((((((p1*ax+p2)*ax+p3)*ax+p4)*ax+p5)*ax+p6)*ax + p7)*ax + p8
-            bot = ((((((q1*ax+q2)*ax+q3)*ax+q4)*ax+q5)*ax+q6)*ax + q7)*ax + q8
-            val = 0.5E0 + (0.5E0 - np.exp(-x*x)*top/bot)
-            if x < 0.0E0:
-                erf[i] = -val
-            else:
-                erf[i] = val
-        elif 4.0E0 < ax < 5.8E0:
-            x2 = x*x
-            t = 1.0E0/x2
-            top = (((r1*t+r2)*t+r3)*t+r4)*t + r5
-            bot = (((s1*t+s2)*t+s3)*t+s4)*t + 1.0E0
-            val = (c-top/ (x2*bot)) / ax
-            val = 0.5E0 + (0.5E0 - np.exp(-x2)*val)
-            if x < 0.0E0:
-                erf[i] = -val
-            else:
-                erf[i] = val
-        elif ax >= 5.8E0:
-            #choose the sign
-            if x < 0.0E0:
-                erf[i] = -1.0E0
-            else:
-                erf[i] = 1.0E0
-
-    return erf
     
     
    

--- a/py/specter/psf/gausshermite.py
+++ b/py/specter/psf/gausshermite.py
@@ -118,13 +118,15 @@ class GaussHermitePSF(PSF):
         #create dict to hold legval cached data
         self.legval_dict = None
 
-        #- Cache hermitenorm polynomials so we don't have to create them
-        #- every time xypix is called
-        #other functions use this too like _gh
-        self._hermitenorm = list()
-        maxdeg = max(hdr['GHDEGX'], hdr['GHDEGY'])
-        for i in range(maxdeg+1):
-            self._hermitenorm.append( sp.hermitenorm(i) )
+        #now that we are doing our own hermite eval in pgh i don't think we need this 
+
+        ##- Cache hermitenorm polynomials so we don't have to create them
+        ##- every time xypix is called
+        ##other functions use this too like _gh
+        #self._hermitenorm = list()
+        #maxdeg = max(hdr['GHDEGX'], hdr['GHDEGY'])
+        #for i in range(maxdeg+1):
+        #    self._hermitenorm.append( sp.hermitenorm(i) )
 
         fx.close()
 
@@ -489,7 +491,7 @@ def custom_erf(y):
     for i,x in enumerate(y):
         ax=abs(x) 
         #change gotos into something sensible
-        if ax < 0.5E0:
+        if ax <= 0.5E0:
             t=x*x
             top = ((((a1*t+a2)*t+a3)*t+a4)*t+a5) + 1.0E0
             bot = ((b1*t+b2)*t+b3)*t + 1.0E0
@@ -498,27 +500,27 @@ def custom_erf(y):
             top = ((((((p1*ax+p2)*ax+p3)*ax+p4)*ax+p5)*ax+p6)*ax + p7)*ax + p8
             bot = ((((((q1*ax+q2)*ax+q3)*ax+q4)*ax+q5)*ax+q6)*ax + q7)*ax + q8
             val = 0.5E0 + (0.5E0 - np.exp(-x*x)*top/bot)
-            if x < 0.0:
+            if x < 0.0E0:
                 erf[i] = -val
             else:
                 erf[i] = val
-        elif 4.0E0 < ax <= 5.8E0:
+        elif 4.0E0 < ax < 5.8E0:
             x2 = x*x
             t = 1.0E0/x2
             top = (((r1*t+r2)*t+r3)*t+r4)*t + r5
             bot = (((s1*t+s2)*t+s3)*t+s4)*t + 1.0E0
             val = (c-top/ (x2*bot)) / ax
             val = 0.5E0 + (0.5E0 - np.exp(-x2)*val)
-            if x < 0.0:
+            if x < 0.0E0:
                 erf[i] = -val
             else:
                 erf[i] = val
-        elif ax > 5.8E0:
+        elif ax >= 5.8E0:
             #choose the sign
-            if x < 0.0:
-                erf[i] = -1.0
+            if x < 0.0E0:
+                erf[i] = -1.0E0
             else:
-                erf[i] = 1.0
+                erf[i] = 1.0E0
 
     return erf
     

--- a/py/specter/test/test_psf.py
+++ b/py/specter/test/test_psf.py
@@ -8,9 +8,11 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import sys
 import os
 import numpy as np
+from scipy import special as sp
 import unittest
 from pkg_resources import resource_filename
 from specter.psf import load_psf
+from specter.util import custom_hermitenorm, custom_erf
 
 class GenericPSFTests(object):
     """
@@ -537,6 +539,39 @@ class GenericPSFTests(object):
 
         #- Check that calling something that isn't in the cache is still ok
         xx, yy, pix = self.psf.xypix(0, ww[0]+1.0)
+
+
+    def test_custom_hermitenorm(self):
+        #need to compare our custom hermite norm function to the scipy one
+        m = 3 #degree of the polynomial
+        u = np.random.uniform(0,10,size=10)
+        #generate scipy polynomial
+        scipy_poly = sp.hermitenorm(m)
+        #evalulate at point u
+        scipy_out = scipy_poly(u)
+        #now try our custom fuction
+        custom_out = custom_hermitenorm(m,u)
+        #check if they're the same
+        self.assertTrue(np.all(scipy_out == custom_out))
+
+
+    def test_custom_erf(self):
+        #try getting full printout to terminal
+        np.set_printoptions(precision=16)
+        #need to compare out custom error function to the scipy one
+        y = np.random.uniform(0,6,size=10).astype(np.float64) #test all branches of loop
+        #try the original scipy
+        scipy_out = sp.erf(y)
+        print("scipy_out")
+        print(scipy_out)
+        #now try our custom version
+        custom_out = custom_erf(y)
+        print("custom_out")
+        print(custom_out)
+        #check if they're the same
+        #self.assertTrue(np.all(scipy_out == custom_out))
+        #self.assertTrue(np.array_equal(scipy_out,custom_out))
+        self.assertTrue(np.all(np.isclose(scipy_out,custom_out)))
 
 #- Test Pixellated PSF format
 class TestPixPSF(GenericPSFTests,unittest.TestCase):

--- a/py/specter/test/test_psf.py
+++ b/py/specter/test/test_psf.py
@@ -556,18 +556,12 @@ class GenericPSFTests(object):
 
 
     def test_custom_erf(self):
-        #try getting full printout to terminal
-        np.set_printoptions(precision=16)
         #need to compare out custom error function to the scipy one
         y = np.random.uniform(0,6,size=10).astype(np.float64) #test all branches of loop
         #try the original scipy
         scipy_out = sp.erf(y)
-        print("scipy_out")
-        print(scipy_out)
         #now try our custom version
         custom_out = custom_erf(y)
-        print("custom_out")
-        print(custom_out)
         #check if they're the same
         #self.assertTrue(np.all(scipy_out == custom_out))
         #self.assertTrue(np.array_equal(scipy_out,custom_out))

--- a/py/specter/util/util.py
+++ b/py/specter/util/util.py
@@ -243,6 +243,7 @@ def legval_numba(x, c):
         c1 = tmp + (c1*x*(2*nd - 1))*nd_inv
     return c0 + c1*x
   
+
 @numba.jit(nopython=True, cache=False)
 def custom_hermitenorm(n, u):
     #below is (mostly) cut and paste from scipy orthogonal_eval.pxd
@@ -270,15 +271,16 @@ def custom_hermitenorm(n, u):
         return res
 
 
-#going to re-implement the scipy erf.f fortran function 
-#in python so we can eventually jit-compile (which currently
-#does not support scipy)
 @numba.jit(nopython=True, cache=False)
 def custom_erf(y):
+    #here we have re-implemented the scipy erf.f fortran function 
+    #in python so we can jit-compile (which currently does not
+    #support scipy)
+
     #have to define a ton of constants
     c=0.564189583547756E0
     ###
-    a1=.771058495001320E-04 
+    a1=0.771058495001320E-04 
     a2=-0.133733772997339E-02
     a3=0.323076579225834E-01
     a4=0.479137145607681E-01

--- a/py/specter/util/util.py
+++ b/py/specter/util/util.py
@@ -242,4 +242,133 @@ def legval_numba(x, c):
         c0 = c[-i] - (c1*(nd - 1))*nd_inv
         c1 = tmp + (c1*x*(2*nd - 1))*nd_inv
     return c0 + c1*x
+  
+@numba.jit(nopython=True, cache=False)
+def custom_hermitenorm(n, u):
+    #below is (mostly) cut and paste from scipy orthogonal_eval.pxd
+    #some modifications have been made to operate on an array
+    #rather than a single value (as in the original version)
+    res=np.zeros(len(u))
+    if n < 0:
+        return (0.0)*np.ones(len(u))
+    elif n == 0:
+        return (1.0)*np.ones(len(u))
+    elif n == 1:
+        return u
+    else:
+        y3 = 0.0
+        y2 = 1.0
+        for i,x in enumerate(u):
+            for k in range(n, 1, -1):
+                y1 = x*y2-k*y3
+                y3 = y2
+                y2 = y1
+            res[i]=x*y2-y3
+            #have to reset before the next iteration
+            y3 = 0.0
+            y2 = 1.0
+        return res
+
+
+#going to re-implement the scipy erf.f fortran function 
+#in python so we can eventually jit-compile (which currently
+#does not support scipy)
+@numba.jit(nopython=True, cache=False)
+def custom_erf(y):
+    #have to define a ton of constants
+    c=0.564189583547756E0
+    ###
+    a1=.771058495001320E-04 
+    a2=-0.133733772997339E-02
+    a3=0.323076579225834E-01
+    a4=0.479137145607681E-01
+    a5=0.128379167095513E+00
+    ###
+    b1=0.301048631703895E-02
+    b2=0.538971687740286E-01
+    b3=0.375795757275549E+00
+    ###
+    p1=-1.36864857382717E-07
+    p2=5.64195517478974E-01
+    p3=7.21175825088309E+00
+    p4=4.31622272220567E+01
+    p5=1.52989285046940E+02
+    p6=3.39320816734344E+02
+    p7=4.51918953711873E+02
+    p8=3.00459261020162E+02
+    ###
+    q1=1.00000000000000E+00
+    q2=1.27827273196294E+01
+    q3=7.70001529352295E+01 
+    q4=2.77585444743988E+02 
+    q5=6.38980264465631E+02
+    q6=9.31354094850610E+02
+    q7=7.90950925327898E+02
+    q8=3.00459260956983E+02
+    ###
+    r1=2.10144126479064E+00
+    r2=2.62370141675169E+01
+    r3=2.13688200555087E+01
+    r4=4.65807828718470E+00
+    r5=2.82094791773523E-01
+    ###
+    s1=9.41537750555460E+01
+    s2=1.87114811799590E+02
+    s3=9.90191814623914E+01
+    s4=1.80124575948747E+01
+    ###
+    #end of constants
+
+    #the orig version is meant for a single point
+    #need to modify to work on an array
+    erf = np.zeros(len(y))
+    for i,x in enumerate(y):
+        ax=abs(x) 
+        #change gotos into something sensible
+        if ax <= 0.5E0:
+            t=x*x
+            top = ((((a1*t+a2)*t+a3)*t+a4)*t+a5) + 1.0E0
+            bot = ((b1*t+b2)*t+b3)*t + 1.0E0
+            erf[i] = x * (top/bot)
+        elif 0.5E0 < ax <= 4.0E0:
+            top = ((((((p1*ax+p2)*ax+p3)*ax+p4)*ax+p5)*ax+p6)*ax + p7)*ax + p8
+            bot = ((((((q1*ax+q2)*ax+q3)*ax+q4)*ax+q5)*ax+q6)*ax + q7)*ax + q8
+            val = 0.5E0 + (0.5E0 - np.exp(-x*x)*top/bot)
+            if x < 0.0E0:
+                erf[i] = -val
+            else:
+                erf[i] = val
+        elif 4.0E0 < ax < 5.8E0:
+            x2 = x*x
+            t = 1.0E0/x2
+            top = (((r1*t+r2)*t+r3)*t+r4)*t + r5
+            bot = (((s1*t+s2)*t+s3)*t+s4)*t + 1.0E0
+            val = (c-top/ (x2*bot)) / ax
+            val = 0.5E0 + (0.5E0 - np.exp(-x2)*val)
+            if x < 0.0E0:
+                erf[i] = -val
+            else:
+                erf[i] = val
+        elif ax >= 5.8E0:
+            #choose the sign
+            if x < 0.0E0:
+                erf[i] = -1.0E0
+            else:
+                erf[i] = 1.0E0
+
+    return erf
     
+    
+   
+
+
+
+
+
+
+
+
+
+
+
+  

--- a/py/specter/util/util.py
+++ b/py/specter/util/util.py
@@ -246,6 +246,20 @@ def legval_numba(x, c):
 
 @numba.jit(nopython=True, cache=False)
 def custom_hermitenorm(n, u):
+    """
+    Custom implementation of scipy.special.hermitenorm to enable jit-compiling
+        with Numba (which as of 10/2018 does not support scipy). This functionality
+        is equivalent to:
+        fn = scipy.special.hermitenorm(n)
+        return fn(u)
+        with the exception that scalar values of u are not supported.
+    Inputs:
+        n: the degree of the hermite polynomial
+        u: (requires array) points at which the polynomial will be evaulated. 
+    Outputs:
+        res: the value of the hermite polynomial at array points(u)
+    """
+
     #below is (mostly) cut and paste from scipy orthogonal_eval.pxd
     #some modifications have been made to operate on an array
     #rather than a single value (as in the original version)
@@ -273,9 +287,19 @@ def custom_hermitenorm(n, u):
 
 @numba.jit(nopython=True, cache=False)
 def custom_erf(y):
-    #here we have re-implemented the scipy erf.f fortran function 
-    #in python so we can jit-compile (which currently does not
-    #support scipy)
+    """
+    Custom implementation of scipy.special.erf to enable jit-compiling
+        with Numba (which as of 10/2018 does not support scipy). This functionality is equilvalent to:
+        scipy.special.erf(y)
+        with the exception that scalar values of y are not supported.
+    Input: y, an array of points at which the error function will be evaluated
+    Output: erf, the value of the error function at points in array y
+    Note: this function has been translated from the original fortran function
+        to python. The original scipy erf function can be found at:
+        https://github.com/scipy/scipy/blob/8dba340293fe20e62e173bdf2c10ae208286692f/scipy/special/cdflib/erf.f
+        Note that this new function introduces a small amount of machine-precision numerical error
+        as compared to the original scipy function. 
+    """
 
     #have to define a ton of constants
     c=0.564189583547756E0


### PR DESCRIPTION
This pull request implements a new version of the pgh function for gausshermite objects. This version of pgh is itself jit-compiled with numba, which in turn calls custom numba versions of scipy.erf and scipy.hermitenorm (because numba presently does not support scipy). This numba-ized version of pgh results in a 24 percent speedup on Haswell and a 33 percent speedup on KNL for desi_extract_spectra. 

It should be noted that the addition of the custom erf function results in the introduction of a small amount of machine-precision numerical error. The sensitivity of some of the linear algebra functions to this error may need to be investigated in further detail. 