### PR TITLE
fixing bug in _gh by replacing with custom hermitenorm function

### DIFF
--- a/py/specter/psf/gausshermite.py
+++ b/py/specter/psf/gausshermite.py
@@ -375,7 +375,7 @@ class GaussHermitePSF(PSF):
                 core_string = 'GH-{}-{}'.format(i,j)
                 self.legval_dict[core_string]=self.coeff[core_string].eval(specrange, wavelengths)
 
-#@numba.jit(nopython=True, cache=False)
+@numba.jit(nopython=True, cache=False)
 def pgh(x, m=0, xc=0.0, sigma=1.0):
     """
     Pixel-integrated (probabilist) Gauss-Hermite function.
@@ -404,29 +404,6 @@ def pgh(x, m=0, xc=0.0, sigma=1.0):
         return 0.5 * (y[1:] - y[0:-1])
 
     
-   
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+  
 
 

--- a/py/specter/psf/gausshermite.py
+++ b/py/specter/psf/gausshermite.py
@@ -317,8 +317,8 @@ class GaussHermitePSF(PSF):
         tails = tailamp*r2 / (tailcore**2 + r2)**(1+tailinde/2.0)
         
         #- Create 1D GaussHermite functions in x and y
-        xfunc1 = [self.gh(x, i, xc, sigma=sigx1) for i in range(degx1+1)]
-        yfunc1 = [self.gh(y, i, yc, sigma=sigy1) for i in range(degy1+1)]        
+        xfunc1 = [gh(x, i, xc, sigma=sigx1) for i in range(degx1+1)]
+        yfunc1 = [gh(y, i, yc, sigma=sigy1) for i in range(degy1+1)]        
         
         
         #- Create core PSF image

--- a/py/specter/psf/psf.py
+++ b/py/specter/psf/psf.py
@@ -691,3 +691,12 @@ class PSF(object):
         this is implemented in specter.psf.gausshermite, everywhere else just an empty function
         """
         pass
+
+    def _value(self, x, y, ispec, wavelength):
+        """
+        this is implemented in specter.psf.gausshermite and specter.psf.spotgrid,
+        everywhere else just an empty function
+        """
+        pass
+
+

--- a/py/specter/test/test_psf.py
+++ b/py/specter/test/test_psf.py
@@ -355,6 +355,15 @@ class GenericPSFTests(object):
         self.assertTrue(A.shape == B.shape)
         self.assertTrue(np.all(A.data == B.data))
 
+    #test psf._value to make sure we haven't broken it
+    def test_value(self):
+        ispec = 0
+        #value expects a single wavelength
+        wave = self.psf.wavelength(0)[0]
+        x = self.psf.x(0, wave)
+        y = self.psf.y(0, wave)
+        img=self.psf._value(x,y,ispec,wave)
+
     #- Test shift of PSF xy solution
     @unittest.expectedFailure
     def test_shift_xy(self):


### PR DESCRIPTION
This PR addresses the bug in GH-72. This bug was introduced during PR #71 and broke the _gh function. We have changed the previous self._hermitenorm to our custom numba-ized function custom_hermitenorm. We have also moved this function outside of the class since passing in self is no longer necessary. We have followed the same procedure used in optimizing the _pgh function in PR #71 .

Since this is now a JIT-compiled function there is likely some speedup, although we haven't made any measurements. 