### PR TITLE
implement oleksandr-pavlyk changes from memory pr 49

### DIFF
--- a/py/specter/util/traceset.py
+++ b/py/specter/util/traceset.py
@@ -26,7 +26,9 @@ class TraceSet(object):
         return self._coeff.shape[0]
         
     def _xnorm(self, x):
-        return 2.0 * (x - self._xmin) / (self._xmax - self._xmin) - 1.0
+        #return 2.0 * (x - self._xmin) / (self._xmax - self._xmin) - 1.0
+        #implement oleksandr-pavlyk's fix from the memory branch 
+        return (x - self._xmin) * (2.0 / (self._xmax - self._xmin)) - 1.0
      
     def eval(self, ispec, x):
         # TODO: this function could be a little more robust/elegant
@@ -98,7 +100,9 @@ class TraceSet(object):
         c = np.zeros((self.ntrace, deg+1))
         for i in range(self.ntrace):
             y = self.eval(i, x)
-            yy = 2.0 * (y-ymin) / (ymax-ymin) - 1.0
+            #yy = 2.0 * (y-ymin) / (ymax-ymin) - 1.0
+            #implement oleksandr-pavlyk's fix from the memory branch
+            yy = (y-ymin) * (2.0 / (ymax-ymin)) - 1.0
             c[i] = legfit(yy, x, deg)
             
         return TraceSet(c, domain=(ymin, ymax))
@@ -122,8 +126,12 @@ def fit_traces(x, yy, deg=5, domain=None):
         xmin, xmax = domain
         
     c = np.zeros((nspec, deg+1))
+    #implement oleksandr-pavlyk's fix from the memory branch
+    xx = x - xmin
+    xx *= 2.0/(xmax-xmin)
+    xx -= 1.0
     for i in range(nspec):
-        xx = 2.0 * (x-xmin) / (xmax-xmin) - 1.0
+        #xx = 2.0 * (x-xmin) / (xmax-xmin) - 1.0
         c[i] = legfit(xx, yy[i], deg)
 
     return TraceSet(c, [xmin, xmax])


### PR DESCRIPTION
This PR implements changes made by @oleksandr-pavlyk in #49 . Since the memory branch has not been merged into master, we are including his (still relevant) changes here. 

These changes result in relatively modest speedups of a few percent. 

It should be noted that a small amount of numerical error is introduced by these changes, somewhat akin to those in #71 . We did confirm that (flux1-flux2)*np.sqrt(ivar) is centered around 0 and its maximum value is 1E-9. 