### PR TITLE
fix NaN flux coming from masked input pixels

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -68,7 +68,7 @@ matrix:
         # Check for sphinx doc build warnings - we do this first because it
         # runs for a long time
         - os: linux
-          env: PYTHON_VERSION=2.7 SETUP_CMD='build_sphinx'
+          env: PYTHON_VERSION=3.6 SETUP_CMD='build_sphinx'
           # -w is an astropy extension
 
         # Try 2.7 and 3.5 python versions with the latest numpy
@@ -79,7 +79,7 @@ matrix:
         #        PIP_DEPENDENCIES=$PIP_ALL_DEPENDENCIES
 
         - os: linux
-          env: PYTHON_VERSION=3.5
+          env: PYTHON_VERSION=3.6
                SETUP_CMD="test"
                CONDA_DEPENDENCIES=$CONDA_ALL_DEPENDENCIES
                PIP_DEPENDENCIES=$PIP_ALL_DEPENDENCIES

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,8 @@ env:
         # These packages will always be installed.
         - CONDA_DEPENDENCIES=''
         # These packages will only be installed if we really need them.
-        - CONDA_ALL_DEPENDENCIES='scipy coverage==3.7.1 requests numba'
+        # - CONDA_ALL_DEPENDENCIES='scipy coverage==3.7.1 requests numba'
+        - CONDA_ALL_DEPENDENCIES='scipy coverage requests numba'
         # These packages will always be installed.
         - PIP_DEPENDENCIES=''
         # These packages will only be installed if we really need them.


### PR DESCRIPTION
This PR fixes desihub/desispec#906 by catching flux=NaN and resetting to flux=ivar=0.0 instead.  The NaNs can occur when the input pixels are entirely masked for a particular spectrum/wavelength.

Tested with
```
srun -n 20 -c 2 desi_proc --mpi --traceshift --scattered-light --nofluxcalib \
  --cameras z4 -n 20200306 -e 53630
```
and confirming that the output frame doesn't have NaN; example in /global/cfs/cdirs/desi/users/sjbailey/spectro/redux/testnan/exposures/20200306/00053630.