### PR TITLE
Configuring specter for ReadTheDocs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ htmlcov
 # Sphinx
 doc/api
 doc/_build
+_build
 
 # iPython
 doc/nb/.ipynb_checkpoints

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,18 @@
+# .readthedocs.yml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Build documentation in the doc/ directory with Sphinx
+sphinx:
+    configuration: doc/conf.py
+
+# Optionally build your docs in additional formats such as PDF and ePub
+formats: all
+
+# Optionally set the version of Python and requirements required to build your docs
+python:
+    version: 3
+    # system_packages: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,7 @@ env:
         # Debug the Travis install process.
         - DEBUG=False
     matrix:
-        - PYTHON_VERSION=2.7 SETUP_CMD='egg_info'
+        - PYTHON_VERSION=3.6 SETUP_CMD='egg_info'
 
 matrix:
     # Don't wait for allowed failures.
@@ -69,8 +69,7 @@ matrix:
         # Check for sphinx doc build warnings - we do this first because it
         # runs for a long time
         - os: linux
-          env: PYTHON_VERSION=3.6 SETUP_CMD='build_sphinx'
-          # -w is an astropy extension
+          env: PYTHON_VERSION=3.6 SETUP_CMD='build_sphinx --warning-is-error'
 
         # Try 2.7 and 3.5 python versions with the latest numpy
         # - os: linux

--- a/README.rst
+++ b/README.rst
@@ -91,11 +91,11 @@ Full Documentation
 
 Please visit `specter on Read the Docs`_
 
-.. image:: https://readthedocs.org/projects/specter/badge/?version=latest
-    :target: http://specter.readthedocs.org/en/latest/
+.. image:: https://readthedocs.org/projects/desi-specter/badge/?version=latest
+    :target: https://desi-specter.readthedocs.io/en/latest/
     :alt: Documentation Status
 
-.. _`specter on Read the Docs`: http://specter.readthedocs.org/en/latest/
+.. _`specter on Read the Docs`: https://desi-specter.readthedocs.io/en/latest/
 
 **This is not actually the specter documentation.  It is some other package
 that happens to also be called "specter".**

--- a/bin/specter
+++ b/bin/specter
@@ -15,6 +15,7 @@ import numpy as np
 import optparse
 import multiprocessing as MP
 from functools import reduce
+from specter.io import read_simspec
 
 #- Parse options
 parser = optparse.OptionParser(
@@ -74,7 +75,7 @@ badopts = False
 if opts.input is None:
     print("ERROR: -i/--input spectra filename required", file=sys.stderr)
     badopts = True
-    
+
 if opts.output is None:
     print("ERROR: -o/--output image filename required", file=sys.stderr)
     badopts = True
@@ -121,12 +122,12 @@ if opts.wavelength is not None:
     wmin, wmax = opts.wavelength
 else:
     wmin = np.min( psf.wavelength(None, y=-0.5) )        #- bottom edge of CCD
-    wmax = np.max( psf.wavelength(None, y=psf.npix_y-0.5) ) #- top edge of CCD 
+    wmax = np.max( psf.wavelength(None, y=psf.npix_y-0.5) ) #- top edge of CCD
     opts.wavelength = [wmin, wmax]
-    
+
 #- Load input spectra
 #- returns dictionary with keys flux, wavelength, units, objtype
-spectra = specter.io.read_simspec(opts.input)
+spectra = read_simspec(opts.input)
 wavelength = spectra['wavelength']
 flux = spectra['flux']
 units = spectra['units']
@@ -158,7 +159,7 @@ else:
     ii = (wmin <= wavelength.min(axis=0)) & (wavelength.max(axis=0) <= wmax)
     wavelength = wavelength[:, ii]
     flux = flux[opts.inspecmin:, ii]
-        
+
 #- Expand objtype into array
 objtype = spectra['objtype']
 if isinstance(objtype, str) and (flux.ndim == 2):
@@ -185,16 +186,16 @@ if units.endswith('/A'):
         wmid = psf.wavelength(i, y=ymid)
         newwave[i] = wmid
         newflux[i] = specter.util.resample(wedges, wavelength[i], flux[i], xedges=True)
-        
+
     wavelength = newwave
     flux = newflux
-    
+
 #- For each spectrum, set flux=0 for wavelengths out of range
 #- When spectral wavelength ranges are different, some may need trimming
 #- even if others don't.
 for i in range(flux.shape[0]):
     iibad = (wavelength[i] < wmin) | (wmax < wavelength[i])
-    flux[i, iibad] = 0.0    
+    flux[i, iibad] = 0.0
 
 #- Convert flux to photons, and 1D -> 2D if needed
 if flux.ndim == 1:
@@ -208,18 +209,18 @@ else:
 
 #- Add sky spectrum
 if opts.sky:
-    sky = specter.io.read_simspec(opts.sky)
+    sky = read_simspec(opts.sky)
     if not units.endswith('/A') or not sky['units'].endswith('/A/arcsec^2'):
         print("I don't know how to combine these units")
         print(units, sky['units'])
         sys.exit(1)
-    
+
     for i in range(opts.nspec):
         wedges = psf.wavelength(i, y=yedges)
         skyflux = specter.util.resample(wedges, sky['wavelength'], sky['flux'], xedges=True)
         skyphot = thru.photons(wavelength[i], skyflux, sky['units'], objtype='SKY')
         photons[i] += skyphot
-    
+
 if opts.trimxy:
     specminmax = specrange[0], specrange[-1]
     waverange = opts.wavelength[0], opts.wavelength[-1]
@@ -238,7 +239,7 @@ else:
     def project(args):
         psf = args['psf']
         return psf.project(args['wavelength'], args['photons'], args['specmin'], args['xyrange'])
-    
+
     #- Setup list of dictionaries with arguments
     arglist = list()
     n = max(1, (len(specrange)+1)//opts.numcores)
@@ -252,7 +253,7 @@ else:
     #- Parallel map to run project(arglist[0]), project(arglist[1]), etc.
     pool = MP.Pool(opts.numcores)
     images = pool.map(project, arglist)
-        
+
     #- Add the individual images
     img = reduce(np.add, images)
 
@@ -264,7 +265,7 @@ define function to
   - get (photons, wavelength, specmin) from input queue
   - process that
   - put resulting image on outut queue
-  
+
 put 8 sets of (photons, wavelength, specmin) into input queue
 start 8 processes with the input, output queues
 wait for them to finish
@@ -313,7 +314,7 @@ if opts.image:
             input_readnoise = np.mean(amp_noise)
         else:
             input_readnoise = np.sqrt(np.median(input_var))   #- ???
-            
+
     fx.close()  #- close input image file
 
 #- Variance to add to new image
@@ -329,12 +330,12 @@ if opts.noise:
     else:
         #- photon shot noise (float -> int)
         img = np.random.poisson(img)
-        
+
         #- Convert to ADU, add gaussian read noise, then integerize
         adu = img/opts.gain
         if opts.readnoise > 0:
             adu += np.random.normal(scale=opts.readnoise/opts.gain, size=img.shape)
-                    
+
         adu = (adu+0.5).astype(int)  #- Integerize ADU
         img = adu * opts.gain        #- back to photons (and back to float)
 
@@ -348,7 +349,7 @@ if opts.image:
         nx = min(input_image.shape[1], img.shape[1])
         img[0:ny, 0:nx] += input_image[0:ny, 0:nx]
         var[0:ny, 0:nx] += input_var[0:ny, 0:nx]
-    
+
 #- Decide what to write for read noise
 if opts.image:
     output_readnoise = input_readnoise
@@ -356,7 +357,7 @@ elif opts.noise:
     output_readnoise = opts.readnoise
 else:
     output_readnoise = 0.0
-        
+
 #- Write output
 print("Writing", opts.output)
 
@@ -382,12 +383,12 @@ else:
 hx = fits.HDUList()
 hx.append(fits.PrimaryHDU(img, header=hdr))
 
-#- Add IVAR HDU 
+#- Add IVAR HDU
 hx.append(fits.ImageHDU(1.0/var, name='IVAR'))
 
 #--- Add additional HDUs with extra info about inputs ---
 if opts.extra:
-    #- Trim arrays to just those with information    
+    #- Trim arrays to just those with information
     ii = np.where(np.any(photons>0, axis=0))[0]
     ii = list(range(ii[0], ii[-1]+1))
     photons = photons[:, ii]
@@ -399,28 +400,28 @@ if opts.extra:
             dtype=[('PHOTONS',     str(photons.dtype), (nwave,)),
                    ('WAVELENGTH',  str(wavelength.dtype), (nwave,)),
                    ])
-        
+
     hdr = fits.Header()
     hdr['SPECMIN'] = (specrange[0], 'First spectrum index')
     hx.append(fits.BinTableHDU(a, header=hdr, name='PHOTONS'))
-    
+
     #- X,Y vs. wavelength
     yy = np.arange(psf.npix_y)
     y = np.tile(yy, opts.nspec).reshape(opts.nspec, psf.npix_y)
     x = np.zeros(y.shape)
     w = np.zeros(y.shape)
-    
+
     for i, ispec in enumerate(specrange):
         w[i] = psf.wavelength(ispec=ispec, y=yy)
         x[i] = psf.x(ispec=ispec, wavelength=w[i])
-    
+
     a = np.array(list(zip(x, y, w)),
                 dtype=[('X', str(x.dtype), (psf.npix_y,)),
                        ('Y', str(y.dtype), (psf.npix_y,)),
                        ('WAVELENGTH',  str(wavelength.dtype), (psf.npix_y,)),
                        ])
     hx.append(fits.BinTableHDU(a, header=hdr, name='XYWAVE'))
-    
+
 hx.writeto(opts.output, clobber=True)
 
 if opts.debug:

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -8,14 +8,50 @@ specter API
 .. automodule:: specter.extract
     :members:
 
+.. automodule:: specter.extract.ex1d
+    :members:
+
+.. automodule:: specter.extract.ex2d
+    :members:
+
 .. automodule:: specter.io
     :members:
 
 .. automodule:: specter.psf
     :members:
 
-.. automodule:: specter.util
+.. automodule:: specter.psf.gausshermite
+    :members:
+
+.. automodule:: specter.psf.gausshermite2
+    :members:
+
+.. automodule:: specter.psf.monospot
+    :members:
+
+.. automodule:: specter.psf.pixpsf
+    :members:
+
+.. automodule:: specter.psf.psf
+    :members:
+
+.. automodule:: specter.psf.spotgrid
     :members:
 
 .. automodule:: specter.throughput
+    :members:
+
+.. automodule:: specter.util
+    :members:
+
+.. automodule:: specter.util.cachedict
+    :members:
+
+.. automodule:: specter.util.pixspline
+    :members:
+
+.. automodule:: specter.util.traceset
+    :members:
+
+.. automodule:: specter.util.util
     :members:

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,7 +5,9 @@ specter change log
 0.9.4 (unreleased)
 ------------------
 
-* No changes yet.
+* Update documentation configuration for ReadTheDocs (PR `#77`_).
+
+.. _`#77`: https://github.com/desihub/specter/pull/77
 
 0.9.3 (2020-04-16)
 ------------------

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -87,6 +87,7 @@ specter change log
 ------------------
 
 PR #40:
+
 * Added full_output option to ex2d to get model image and metrics based upon
   goodness of fit
 * PSFs can specify their model error with PSFERR header keyword; default 0.01

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -121,7 +121,7 @@ napoleon_include_private_with_doc = True
 # some external dependencies are not met at build time and break the
 # building process.
 autodoc_mock_imports = []
-for missing in ('astropy', 'desiutil', 'scipy'):
+for missing in ('astropy', 'desiutil', 'numba', 'scipy'):
     try:
         foo = import_module(missing)
     except ImportError:

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -14,7 +14,7 @@
 
 import sys
 import os
-import os.path
+from importlib import import_module
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -25,17 +25,6 @@ sys.path.insert(0, os.path.abspath('../py'))
 
 # If your documentation needs a minimal Sphinx version, state it here.
 
-try:
-    import sphinx.ext.napoleon
-    napoleon_extension = 'sphinx.ext.napoleon'
-except ImportError:
-    try:
-        import sphinxcontrib.napoleon
-        napoleon_extension = 'sphinxcontrib.napoleon'
-        needs_sphinx = '1.2'
-    except ImportError:
-        needs_sphinx = '1.3'
-
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
@@ -45,12 +34,12 @@ extensions = [
     'sphinx.ext.todo',
     'sphinx.ext.mathjax',
     'sphinx.ext.viewcode',
-    napoleon_extension
+    'sphinx.ext.napoleon'
 ]
 
 # Configuration for intersphinx, copied from astropy.
 intersphinx_mapping = {
-    'python': ('http://docs.python.org/', None),
+    'python': ('http://docs.python.org/3/', None),
     # 'python3': ('http://docs.python.org/3/', path.abspath(path.join(path.dirname(__file__), 'local/python3links.inv'))),
     'numpy': ('http://docs.scipy.org/doc/numpy/', None),
     'scipy': ('http://docs.scipy.org/doc/scipy/reference/', None),
@@ -73,7 +62,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'specter'
-copyright = u'2014-2016, DESI Collaboration'
+copyright = u'2014-2020, DESI Collaboration'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -132,7 +121,7 @@ napoleon_include_private_with_doc = True
 # some external dependencies are not met at build time and break the
 # building process.
 autodoc_mock_imports = []
-for missing in ('astropy', 'desiutil'):
+for missing in ('astropy', 'desiutil', 'scipy'):
     try:
         foo = import_module(missing)
     except ImportError:

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -128,6 +128,16 @@ keep_warnings = True
 # Include functions that begin with an underscore, e.g. _private().
 napoleon_include_private_with_doc = True
 
+# This value contains a list of modules to be mocked up. This is useful when
+# some external dependencies are not met at build time and break the
+# building process.
+autodoc_mock_imports = []
+for missing in ('astropy', 'desiutil'):
+    try:
+        foo = import_module(missing)
+    except ImportError:
+        autodoc_mock_imports.append(missing)
+
 # -- Options for HTML output ----------------------------------------------
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -121,7 +121,7 @@ napoleon_include_private_with_doc = True
 # some external dependencies are not met at build time and break the
 # building process.
 autodoc_mock_imports = []
-for missing in ('astropy', 'desiutil', 'numba', 'scipy'):
+for missing in ('astropy', 'desiutil', 'numba', 'numpy', 'scipy'):
     try:
         foo = import_module(missing)
     except ImportError:

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -14,7 +14,7 @@ Contents
    :maxdepth: 1
 
    api
-   release_notes
+   changes
    data_files
    datamodel/index
 

--- a/py/specter/__init__.py
+++ b/py/specter/__init__.py
@@ -14,6 +14,4 @@ defines the interface for any PSF object.  Specific instruments
 
 to describe how a given spectrum ispec and wavelength project onto the CCD.
 """
-import specter.io
-
 from ._version import __version__

--- a/py/specter/extract/ex1d.py
+++ b/py/specter/extract/ex1d.py
@@ -16,55 +16,61 @@ import math
 
 from specter.util import gausspix, weighted_solve
 
-def ex1d(img, mask, psf, readnoise=2.5,
-              specrange=None, yrange=None,
-              nspec_per_group=20, debug=False, model=False):
-    """
-    Extract spectra from an image using row-by-row weighted extraction.
-    
-    Inputs:
-        img[ny, nx]     CCD image
-        mask[ny, nx]    0=good, non-zero=bad
-        psf object
-        
-    Optional Inputs:
-        readnoise = CCD readnoise
-        specrange = (specmin, specmax) Spectral range to extract (default all)
-        yrange = (ymin, ymax) CCD y (row) range to extract (default all rows)
-        --> ranges are python-like, i.e. yrange=(0,100) extracts 100 rows
-            from 0 to 99 inclusive but not row 100.
-            
-        groupspec: extract spectra in groups of N spectra
-            (faster if spectra are physically separated into non-overlapping
-            groups)
-            
-        debug: if True, stop with prompt after each row
-        
-    Returns:
-        spectra[nspec, ny]   - extracted spectra
-        specivar[nspec, ny]  - inverse variance of spectra  
+def ex1d(img, mask, psf, readnoise=2.5, specrange=None, yrange=None,
+         nspec_per_group=20, debug=False, model=False):
+    """Extract spectra from an image using row-by-row weighted extraction.
+
+    Parameters
+    ----------
+    img : array-like
+        CCD image.
+    mask : array-like
+        Image mask, 0=good, non-zero=bad
+    psf : object
+        PSF object.
+    readnoise : float, optional
+        CCD readnoise
+    specrange : list, optional
+        (specmin, specmax) Spectral range to extract (default all)
+    yrange : list, optional
+        (ymin, ymax) CCD y (row) range to extract (default all rows)
+        ranges are python-like, *i.e.* yrange=(0,100) extracts 100 rows
+        from 0 to 99 inclusive but not row 100.
+    nspec_per_group : int, optional
+        Extract spectra in groups of N spectra (faster if spectra are physically
+        separated into non-overlapping groups).
+    debug : bool, optional
+        If ``True``, stop with prompt after each row
+    model : bool, optional
+        Unknown parameter
+
+    Returns
+    -------
+    tuple
+        Tuple containing spectra[nspec, ny] the extracted spectra,
+        specivar[nspec, ny] the inverse variance of spectra.
     """
 
     #- Range of spectra to extract
-    specmin, specmax = specrange if (specrange is not None) else (0, psf.nspec)        
+    specmin, specmax = specrange if (specrange is not None) else (0, psf.nspec)
     nspec = specmax - specmin
-    
+
     #- Rows to extract
     ymin, ymax = yrange if (yrange is not None) else (0, psf.npix_y)
     ny = ymax - ymin
     nx = img.shape[0]
     xx = np.arange(nx)
-    
+
     spectra = np.zeros((nspec, ny))
     specivar = np.zeros((nspec, ny))
-    
+
     if model:
         imgmodel = np.zeros(img.shape)
-        
+
     #- Loop over groups of spectra
     for speclo in range(specmin, specmax, nspec_per_group):
         spechi = min(specmax, speclo+nspec_per_group)
-                
+
         #- Calc trace centers (x0) and gaussian sigmas (xsigma) for each row
         allx0 = np.zeros((nspec_per_group, ymax-ymin))
         allxsigma = np.zeros((nspec_per_group, ymax-ymin))
@@ -73,12 +79,12 @@ def ex1d(img, mask, psf, readnoise=2.5,
             w = psf.wavelength(ispec, y=rows)
             allx0[ispec-speclo] = psf.x(ispec, w)
             allxsigma[ispec-speclo] = psf.xsigma(ispec, w)
-                
+
         #- Loop over CCD rows
         for irow, row in enumerate(range(ymin, ymax)):
             if debug and row%500 == 0:
                 print("Row {:3d} spectra {}:{}".format(row, speclo, spechi))
-        
+
             #- Determine x range covered for this row of this group of spectra
             wlo = psf.wavelength(speclo, y=row)
             whi = psf.wavelength(spechi-1, y=row)
@@ -86,12 +92,12 @@ def ex1d(img, mask, psf, readnoise=2.5,
                 xmin = 0
             else:
                 xmin = int(0.5*(psf.x(speclo-1, wlo) + psf.x(speclo, wlo)))
-        
+
             if spechi >= psf.nspec:
                 xmax = psf.npix_x
             else:
                 xmax = int(0.5*(psf.x(spechi-1, wlo) + psf.x(spechi, wlo)) + 1)
-                
+
             #- Design matrix for pixels = A * flux for this row
             A = np.zeros( (xmax-xmin, spechi-speclo) )
             for ispec in range(speclo, spechi):
@@ -100,13 +106,13 @@ def ex1d(img, mask, psf, readnoise=2.5,
                 # xsigma = psf.xsigma(ispec, w)
                 x0 = allx0[ispec-speclo, irow]
                 xsigma = allxsigma[ispec-speclo, irow]
-            
+
                 #- x range for single spectrum on single row
                 xlo = max(xmin, int(x0-5*xsigma))
                 xhi = min(xmax, int(x0+5*xsigma+1))
-            
+
                 A[xlo-xmin:xhi-xmin, ispec-speclo] = gausspix(xx[xlo:xhi], x0, xsigma)
-            
+
             #- Original solve, weighting by input ivar
             ### tmpspec, iCov = weighted_solve(A, img[row, xmin:xmax], ivar[row, xmin:xmax])
 
@@ -114,25 +120,23 @@ def ex1d(img, mask, psf, readnoise=2.5,
             nx = xmax-xmin
             xvar = np.ones(nx)*readnoise**2 * (mask[row, xmin:xmax] == 0)
             tmpspec, iCov = weighted_solve(A, img[row, xmin:xmax], 1.0/xvar)
-            
+
             #- Re-extract with weight incluing model shot noise
             xvar = (A.dot(tmpspec) + readnoise**2) * (mask[row, xmin:xmax] == 0)
             tmpspec, iCov = weighted_solve(A, img[row, xmin:xmax], 1.0/xvar)
 
             if model:
                 imgmodel[row, xmin:xmax] = A.dot(tmpspec)
-                
+
             spectra[speclo-specmin:spechi-specmin, row-ymin] = tmpspec
-            specivar[speclo-specmin:spechi-specmin, row-ymin] = iCov.diagonal()   
-            
+            specivar[speclo-specmin:spechi-specmin, row-ymin] = iCov.diagonal()
+
             if debug:
                 print(speclo, row)
                 import IPython
-                IPython.embed()                
-                
+                IPython.embed()
+
     if model:
         return spectra, specivar, imgmodel
     else:
         return spectra, specivar
-    
-        

--- a/py/specter/extract/ex1d.py
+++ b/py/specter/extract/ex1d.py
@@ -1,6 +1,7 @@
-#!/usr/bin/env python
-
 """
+specter.extract.ex1d
+====================
+
 1D Extraction like Horne 1986
 
 Stephen Bailey, LBL

--- a/py/specter/extract/ex2d.py
+++ b/py/specter/extract/ex2d.py
@@ -1,4 +1,7 @@
 """
+specter.extract.ex2d
+====================
+
 2D Spectroperfectionism extractions
 """
 from __future__ import absolute_import, division, print_function, unicode_literals

--- a/py/specter/psf/gausshermite.py
+++ b/py/specter/psf/gausshermite.py
@@ -1,5 +1,7 @@
-#!/usr/bin/env python
 """
+specter.psf.gausshermite
+========================
+
 GaussHermitePSF - PSF modeled with 2D Gauss-Hermite polynomials as generated
 by the specex package at https://github.com/julienguy/specex
 

--- a/py/specter/psf/monospot.py
+++ b/py/specter/psf/monospot.py
@@ -1,4 +1,7 @@
 """
+specter.psf.monospot
+====================
+
 MonoSpotPSF - ...
 """
 
@@ -17,25 +20,25 @@ class MonoSpotPSF(PSF):
         which spot[y,x] to use.  If overriding spot, scale gives ratio of
         spot pixel-size to CCD pixel-size.  Must be >1 and evenly divisible
         by spot dimensions.
-        
+
         See specter.psf.PSF for futher details
         """
         #- Use PSF class to Load Generic PSF values (x, y, wavelength, ...)
         PSF.__init__(self, filename)
-        
+
         if spot is None:
             self._spot = fits.getdata(filename, 'SPOT')
             self._scale = fits.getheader(filename, 'SPOT')['SCALE']
         else:
             self._spot = spot.copy()
             self._scale = scale
-        
+
     def _xypix(self, ispec, wavelength, ispec_cache=None, iwave_cache=None):
         """
         Return xslice, yslice, pix for PSF at spectrum ispec, wavelength
         """
         assert 0 <= ispec < self.nspec
-        
+
         xc, yc = self.xy(ispec, wavelength)
         scale = self._scale  #- shorthand
 
@@ -59,7 +62,7 @@ class MonoSpotPSF(PSF):
         ccdpix = ccdpix.clip(0)
         ccdpix /= np.sum(ccdpix)
 
-        #- Find where the [0,0] pixel goes on the CCD 
+        #- Find where the [0,0] pixel goes on the CCD
         xccd = int(xc - ccdpix.shape[1]//2 + 1)
         yccd = int(yc - ccdpix.shape[0]//2 + 1)
 
@@ -73,31 +76,31 @@ class MonoSpotPSF(PSF):
 # def __init__(self, x, y, w, spot, scale=1):
 #     """
 #     Create new MonoSpotPSF
-#     
+#
 #     Inputs:
 #         x[nspec, *] : 2D array of x-centroids on CCD
 #         y[nspec, *] : 2D array of y-centroids on CCD
 #         w[nspec, *] : 2D array of wavelengths on CCD
-#         
+#
 #         spot[ny,nx] : 2D spot image to use everywhere on CCD
 #         scale : ratio of spot pixel scale to CCD pixel scale.
 #                 Must be evenly divisible by ny,nx.
-# 
+#
 #     Notes:
 #     The second dimension of x,y,w is arbitrary, but the resolution
 #     should be fine enough that liner interpolation is valid.
 #     e.g. numpy.interp(yt, y[i], w[i]) should give the wavelength of
 #     spectrum i at CCD row = yt.
-#     
+#
 #     If spot.shape == (120,120) and scale=10, then 10 pixels of spot
 #     correspond to 1 CCD pixel and the spot covers an area of (12x12)
 #     CCD pixels.
 #     """
-# 
+#
 #     assert x.shape == y.shape == w.shape
 #     assert spot.shape[0] % scale == 0
 #     assert spot.shape[1] % scale == 0
-#     
+#
 #     self._nspec = x.shape[0]
 #     self._x = x.copy()
 #     self._y = y.copy()

--- a/py/specter/psf/pixpsf.py
+++ b/py/specter/psf/pixpsf.py
@@ -1,6 +1,7 @@
-#!/usr/bin/env python
-
 """
+specter.psf.pixpsf
+==================
+
 Pixelated 2D PSF
 
 David Schlegel & Stephen Bailey, Summer 2011
@@ -14,12 +15,12 @@ from specter.psf import PSF
 from specter.util import sincshift
 
 #- Turn off complex -> real warnings in sinc interpolation
-import warnings 
+import warnings
 try:
 	warnings.simplefilter("ignore", np.ComplexWarning)
 except   AttributeError:
 	pass
-	
+
 class PixPSF(PSF):
     """
     Pixelated PSF[ny, nx] = Ic[ny,nx] + x*Ix[ny, nx] + y*Iy[ny,nx] + ...
@@ -30,18 +31,18 @@ class PixPSF(PSF):
         """
         #- Use PSF class to Load Generic PSF values (x, y, wavelength, ...)
         PSF.__init__(self, filename)
-        
+
         #- Additional headers are a custom format for the pixelated psf
         fx = fits.open(filename, memmap=False)
         self.nexp     = fx[3].data.view(np.ndarray)  #- icoeff xexp yexp
         self.xyscale  = fx[4].data.view(np.ndarray)  #- ifiber igroup x0 xscale y0 yscale
         self.psfimage = fx[5].data.view(np.ndarray)  #- [igroup, icoeff, iy, ix]
         fx.close()
-                
+
     def _xypix(self, ispec, wavelength, ispec_cache=None, iwave_cache=None):
         """
         Evaluate PSF for a given spectrum and wavelength
-        
+
         returns xslice, yslice, pixels[yslice, xslice]
         """
         #- Get fiber group and scaling factors for this spectrum
@@ -50,49 +51,49 @@ class PixPSF(PSF):
         xscale = self.xyscale['XSCALE'][ispec]
         y0     = self.xyscale['Y0'][ispec]
         yscale = self.xyscale['YSCALE'][ispec]
-        
+
         #- Get x and y centroid
         x, y = self.xy(ispec, wavelength)
-        
+
         #- Rescale units
         xx = xscale * (x - x0)
         yy = yscale * (y - y0)
-        
+
         #- Generate PSF image at (x,y)
         psfimage = np.zeros(self.psfimage.shape[2:4])
         for i in range(self.psfimage.shape[1]):
             nx = self.nexp['XEXP'][i]
             ny = self.nexp['YEXP'][i]
             psfimage += xx**nx * yy**ny * self.psfimage[igroup, i]
-                                
+
         #- Sinc Interpolate
         dx = x - int(round(x))
         dy = y - int(round(y))
         psfimage = sincshift(psfimage, dx, dy)
-        
+
         #- Check boundaries
         ny, nx = psfimage.shape
         ix = int(round(x))
         iy = int(round(y))
-        
+
         xmin = max(0, ix-nx//2)
         xmax = min(self.npix_x, ix+nx//2+1)
         ymin = max(0, iy-ny//2)
         ymax = min(self.npix_y, iy+ny//2+1)
-                
+
         if ix < nx//2:
             psfimage = psfimage[:, nx//2-ix:]
         if iy < ny//2:
             psfimage = psfimage[ny//2-iy:, :]
-        
+
         if ix+nx//2+1 > self.npix_x:
             dx = self.npix_x - (ix+nx//2+1)
             psfimage = psfimage[:, :dx]
-            
+
         if iy+ny//2+1 > self.npix_y:
             dy = self.npix_y - (iy+ny//2+1)
             psfimage = psfimage[:dy, :]
-        
+
         xslice = slice(xmin, xmax)
         yslice = slice(ymin, ymax)
 
@@ -101,10 +102,8 @@ class PixPSF(PSF):
 
         #- Normalize integral to 1.0
         psfimage /= psfimage.sum()
-        
+
         assert xslice.stop-xslice.start == psfimage.shape[1]
         assert yslice.stop-yslice.start == psfimage.shape[0]
 
         return xslice, yslice, psfimage
-
-

--- a/py/specter/psf/psf.py
+++ b/py/specter/psf/psf.py
@@ -1,6 +1,7 @@
-#!/usr/bin/env python
-
 """
+specter.psf.psf
+===============
+
 Base class for 2D PSFs
 
 Provides PSF base class which defines the interface for other code

--- a/py/specter/psf/spotgrid.py
+++ b/py/specter/psf/spotgrid.py
@@ -1,5 +1,7 @@
-#!/usr/bin/env python
 """
+specter.psf.spotgrid
+====================
+
 SpotGridPSF - Linear interpolate hi-res sampled spots to model PSF
 
 Stephen Bailey

--- a/py/specter/psf/spotgrid.py
+++ b/py/specter/psf/spotgrid.py
@@ -24,12 +24,12 @@ class SpotGridPSF(PSF):
     def __init__(self, filename):
         """
         Initialize SpotGridPSF from input file
-        
+
         See specter.psf.PSF for futher details
         """
         #- Use PSF class to Load Generic PSF values (x, y, wavelength, ...)
         PSF.__init__(self, filename)
-        
+
         #- Load extensions specific to this PSF type
         fx = fits.open(filename, memmap=False)
         self._spots = fx['SPOTS'].data        #- PSF spots
@@ -38,47 +38,47 @@ class SpotGridPSF(PSF):
         self._fiberpos = fx['FIBERPOS'].data  #- Location of fibers on slit
         self._spotpos = fx['SPOTPOS'].data    #- Slit loc of sampled spots
         self._spotwave = fx['SPOTWAVE'].data  #- Wavelengths of spots
-        
+
         #- 2D linerar interpolators
         pp = self._spotpos
         ww = self._spotwave
         self._fspot = LinearInterp2D(pp, ww, self._spots)
         # self._fx    = LinearInterp2D(pp, ww, self._spotx)
         # self._fy    = LinearInterp2D(pp, ww, self._spoty)
-        
+
         #- Read spot vs. CCD pixel scales from header
         hdr = fx[0].header
         self.CcdPixelSize = hdr['CCDPIXSZ']  #- CCD pixel size in mm
         self.SpotPixelSize = hdr['PIXSIZE']  #- Spot pixel size in mm
-        
+
         fx.close()
-        
+
     def _xypix(self, ispec, wavelength, ispec_cache=None, iwave_cache=None):
         """
         Return xslice, yslice, pix for PSF at spectrum ispec, wavelength
         """
         return self._xypix_interp(ispec, wavelength)
-    
+
     def _xypix_interp(self, ispec, wavelength):
         """
         Return xslice, yslice, pix for PSF at spectrum ispec, wavelength
         """
-        
+
         #- Ratio of CCD to Spot pixel sizes
         rebin = int(self.CcdPixelSize / self.SpotPixelSize)
-        
+
         p, w = self._fiberpos[ispec], wavelength
         pix_spot_values=self._fspot(p, w).astype(np.float64)
         nx_spot=pix_spot_values.shape[1]
         ny_spot=pix_spot_values.shape[0]
         nx_ccd=nx_spot//rebin+1 # add one bin because of resampling
         ny_ccd=ny_spot//rebin+1 # add one bin because of resampling
-        
+
         xc, yc = self.xy(ispec, wavelength) # center of PSF in CCD coordinates
-        
+
         # resampled spot grid
-        resampled_pix_spot_values=new_pixshift(xc,yc,pix_spot_values,rebin)       
-            
+        resampled_pix_spot_values=new_pixshift(xc,yc,pix_spot_values,rebin)
+
         # rebinning
         ccd_pix_spot_values=resampled_pix_spot_values.reshape(ny_spot+rebin,nx_ccd,rebin).sum(2).reshape(ny_ccd,rebin,nx_ccd).sum(1)
         # make sure it's positive
@@ -92,12 +92,12 @@ class SpotGridPSF(PSF):
         y_ccd_begin = int(np.floor(yc))-ny_ccd//2+1  # begin of CCD coordinate stamp
         xx = slice(x_ccd_begin, (x_ccd_begin+nx_ccd))
         yy = slice(y_ccd_begin, (y_ccd_begin+ny_ccd))
-        
+
         return xx,yy,ccd_pix_spot_values
 
-        
-        
-        
+
+
+
     def _value(self, x, y, ispec, wavelength):
 
         """
@@ -110,7 +110,7 @@ class SpotGridPSF(PSF):
           wavelength: wavelength
         """
 
-        
+
         p, w = self._fiberpos[ispec], wavelength
         pix_spot_values=self._fspot(p, w)
         nx_spot=pix_spot_values.shape[1]
@@ -120,10 +120,10 @@ class SpotGridPSF(PSF):
         spline=scipy.interpolate.RectBivariateSpline(y_spot,x_spot,pix_spot_values,kx=2, ky=2, s=0)
         xc, yc = self.xy(ispec, wavelength) # center of PSF in CCD coordinates
         ratio=self.CcdPixelSize/self.SpotPixelSize
-        
+
         xr=x.ravel()
         yr=y.ravel()
-        
+
         #img=spline((x-xc)*ratio,(y-yc)*ratio)
         #return img/np.sum(img)
         img=np.zeros(xr.shape)
@@ -134,11 +134,21 @@ class SpotGridPSF(PSF):
 import numba
 @numba.jit(nopython=True,cache=False)
 def new_pixshift(xc,yc,pix_spot_values,rebin):
-    """
-    Inputs: xc, yc are center of the PSF in ccd coordinates
-            pix_spot_values is a 2D array of interpolated values
-            rebin is the ratio of spot to ccd pixel size
-    Outputs: resampled_pix_spot_values, the resampled and scaled 2D array of pix_spot_values
+    """Does a new pixel shift.
+
+    Parameters
+    ----------
+    xc, yc : array-like
+        Center of the PSF in CCD coordinates.
+    pix_spot_values : array-like
+        2D array of interpolated values.
+    rebin : array-like
+        Ratio of spot to CCD pixel size.
+
+    Returns
+    -------
+    array-like
+        The resampled and scaled 2D array of `pix_spot_values`.
     """
     # fraction pixel offset requiring interpolation
     shiftx=xc*rebin-int(math.floor(xc*rebin)) # positive value between 0 and 1
@@ -147,21 +157,18 @@ def new_pixshift(xc,yc,pix_spot_values,rebin):
     w00=(1-shifty)*(1-shiftx)
     w10=shifty*(1-shiftx)
     w01=(1-shifty)*shiftx
-    w11=shifty*shiftx        
+    w11=shifty*shiftx
     # now the rest of the offset is an integer shift
     dx=int(np.floor(xc*rebin))-int(math.floor(xc))*rebin # positive integer between 0 and 14
     dy=int(np.floor(yc*rebin))-int(math.floor(yc))*rebin # positive integer between 0 and 14
     ny_spot, nx_spot = pix_spot_values.shape
-    #preallocate 
+    #preallocate
     resampled_pix_spot_values=np.zeros((ny_spot+rebin,nx_spot+rebin))
     for i in range(0,ny_spot):
-        for j in range(0,nx_spot):  
-            resampled_pix_spot_values[dy+i,dx+j]       += w00*pix_spot_values[i,j] 
+        for j in range(0,nx_spot):
+            resampled_pix_spot_values[dy+i,dx+j]       += w00*pix_spot_values[i,j]
             resampled_pix_spot_values[dy+1+i,dx+j]     += w10*pix_spot_values[i,j]
             resampled_pix_spot_values[dy+i,dx+1+j]     += w01*pix_spot_values[i,j]
-            resampled_pix_spot_values[dy+1+i,dx+1+j]   += w11*pix_spot_values[i,j] 
+            resampled_pix_spot_values[dy+1+i,dx+1+j]   += w11*pix_spot_values[i,j]
 
-    return resampled_pix_spot_values        
-       
-
- 
+    return resampled_pix_spot_values

--- a/py/specter/util/cachedict.py
+++ b/py/specter/util/cachedict.py
@@ -1,4 +1,7 @@
 """
+specter.util.cachedict
+======================
+
 Implement a dictionary that caches the last N entries and throws the rest away
 """
 
@@ -26,16 +29,15 @@ class CacheDict(dict):
     #- object first to get those right, before calling __setitem__
     def __reduce__(self):
         return type(self), (self._n, dict(self))
-        
+
     def __setitem__(self, key, value):
         """Sets the key/value, possibly dropping an earlier cached key/value"""
         if key in self:
             return
-       
+
         i = self._current = (self._current + 1) % self._n
         if self._keys[i] is not None:
             del self[self._keys[i]]
-            
+
         self._keys[i] = key
         dict.__setitem__(self, key, value)
-        

--- a/py/specter/util/traceset.py
+++ b/py/specter/util/traceset.py
@@ -1,4 +1,7 @@
 """
+specter.util.traceset
+=====================
+
 Handle sets of Legendre coefficients
 """
 
@@ -20,16 +23,16 @@ class TraceSet(object):
         self._coeff = coeff.copy()
         self._xmin = domain[0]
         self._xmax = domain[1]
-    
+
     @property
-    def ntrace(self):    
+    def ntrace(self):
         return self._coeff.shape[0]
-        
+
     def _xnorm(self, x):
         #return 2.0 * (x - self._xmin) / (self._xmax - self._xmin) - 1.0
-        #implement oleksandr-pavlyk's fix from the memory branch 
+        #implement oleksandr-pavlyk's fix from the memory branch
         return (x - self._xmin) * (2.0 / (self._xmax - self._xmin)) - 1.0
-     
+
     def eval(self, ispec, x):
         # TODO: this function could be a little more robust/elegant
         xx = np.array(self._xnorm(x))
@@ -43,7 +46,7 @@ class TraceSet(object):
             #in this case ispec is coming from the cached branch of xypix, which means
             #that we need to use nspec instead of ispec due to re-indexing
             nspec = spec_max - spec_min
-            nwave = len(x)            
+            nwave = len(x)
 
         #numba requires f8 or smaller
         if tuple_input is False:
@@ -64,7 +67,7 @@ class TraceSet(object):
             y=np.zeros([nspec, nwave])
             for i in range(nspec):
                 y[i,:]=legval_numba(xx, cc_numba[i])
-            return y    
+            return y
 
         else:
             #ispec may sometimes be None
@@ -81,11 +84,11 @@ class TraceSet(object):
                     y.append(legval_numba(xx, cc_i))
 
             return np.array(y)
-   
-            
+
+
     # def __call__(self, ispec, x):
     #     return self.eval(ispec, x)
-            
+
     def invert(self, domain=None, deg=None):
         """
         Return a traceset modeling x vs. y instead of y vs. x
@@ -96,7 +99,7 @@ class TraceSet(object):
         x = np.linspace(self._xmin, self._xmax, 1000)
         if deg is None:
             deg = self._coeff.shape[1]+2
-            
+
         c = np.zeros((self.ntrace, deg+1))
         for i in range(self.ntrace):
             y = self.eval(i, x)
@@ -104,13 +107,13 @@ class TraceSet(object):
             #implement oleksandr-pavlyk's fix from the memory branch
             yy = (y-ymin) * (2.0 / (ymax-ymin)) - 1.0
             c[i] = legfit(yy, x, deg)
-            
+
         return TraceSet(c, domain=(ymin, ymax))
-            
+
 def fit_traces(x, yy, deg=5, domain=None):
     """
     returns TraceSet object modeling y[i] vs. x
-    
+
     Args:
         x : 1D array
         y : 2D array[nspec, nx]
@@ -124,7 +127,7 @@ def fit_traces(x, yy, deg=5, domain=None):
         xmin, xmax = x[0], x[-1]
     else:
         xmin, xmax = domain
-        
+
     c = np.zeros((nspec, deg+1))
     #implement oleksandr-pavlyk's fix from the memory branch
     xx = x - xmin
@@ -135,5 +138,3 @@ def fit_traces(x, yy, deg=5, domain=None):
         c[i] = legfit(xx, yy[i], deg)
 
     return TraceSet(c, [xmin, xmax])
-
-    

--- a/py/specter/util/util.py
+++ b/py/specter/util/util.py
@@ -1,4 +1,7 @@
 """
+specter.util.util
+=================
+
 Utility functions and classes for specter
 
 Stephen Bailey


### PR DESCRIPTION
This PR updates the specter documentation and fixes a few import errors under the hood.  I selected [desi-specter](https://desi-specter.readthedocs.io/en/rtd-configuration/) for the name.  There are probably still a few minor test failures to clean up.

After merging, we can make https://desi-specter.readthedocs.io/en/latest/ available (it tracks master), and after the next tag, we can make https://desi-specter.readthedocs.io/en/stable/ available.