### PR TITLE
don't crash on heavily masked inputs

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,7 +5,7 @@ specter change log
 0.9.3 (unreleased)
 ------------------
 
-* No changes yet.
+* Improve handling of heavily (or completely) masked inputs (PR #78).
 
 0.9.2 (2020-04-07)
 ------------------


### PR DESCRIPTION
This PR improves the handling of extractions when most or all of the input pixels are masked.  It isn't perfect, but it at least avoids a crash that we were getting with an andes test run:
```
desi_extract_spectra -w 7520.0,9824.0,0.8 --psferr 0.1 --barycentric-correction \
  -i /global/cfs/cdirs/desi/spectro/redux/andes/preproc/20200306/00053610/preproc-z4-00053610.fits \
  -p /global/cfs/cdirs/desi/spectro/redux/andes/exposures/20200306/00053610/psf-z4-00053610.fits \
  --specmin 150 --nspec 25 \
  -o $SCRATCH/frame-z4-00053610.fits
```
The data were pretty pathological on one amp resulting in a swiss-cheese mask.  This could be further augmented by masking the input data on bad amps with imageivar=0.0.

