### PR TITLE
fix pixelated Gauss-Hermite integration last bin bug

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -5,7 +5,7 @@ specter change log
 0.9.4 (unreleased)
 ------------------
 
-* No changes yet.
+* Fix last-bin bug in pixellated Gauss-Hermite integration (PR #79).
 
 0.9.3 (2020-04-16)
 ------------------

--- a/py/specter/psf/gausshermite.py
+++ b/py/specter/psf/gausshermite.py
@@ -411,7 +411,7 @@ def pgh(x, m=0, xc=0.0, sigma=1.0):
 
     #- Evaluate H[m-1] at half-pixel offsets above and below x
     dx = x-xc-0.5
-    u = np.concatenate( (dx, dx[-1:]+0.5) ) / sigma
+    u = np.concatenate( (dx, dx[-1:]+1.0) ) / sigma
         
     if m > 0:
         y  = -custom_hermitenorm(m-1,u) * np.exp(-0.5 * u**2) / np.sqrt(2. * np.pi)

--- a/py/specter/psf/gausshermite2.py
+++ b/py/specter/psf/gausshermite2.py
@@ -115,7 +115,7 @@ class GaussHermite2PSF(PSF):
 
         #- Evaluate H[m-1] at half-pixel offsets above and below x
         dx = x-xc-0.5
-        u = np.concatenate( (dx, dx[-1:]+0.5) ) / sigma
+        u = np.concatenate( (dx, dx[-1:]+1.0) ) / sigma
         
         if m > 0:
             y = -self._hermitenorm[m-1](u) * np.exp(-0.5 * u**2) / np.sqrt(2. * np.pi)


### PR DESCRIPTION
This PR fixes a 6-year-old bug in the pixellated Gauss-Hermite integration, where the last bin was only integrated for half a bin instead of a full bin.  I'm pretty sure this PR is correct though I would appreciate a cross check, perhaps from @lastephey or @julienguy .

Mea culpa: I was the one who introduced the bug 6 years ago; the original pixellated Gauss-Hermite code from Adam Bolton was correct and I broke it in an "optimization" in how the bin boundaries are calculated.