### PR TITLE
Reproducibility and clobber

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ env:
         # to repeat them for all configurations.
         # - NUMPY_VERSION=1.10
         # - SCIPY_VERSION=0.17
-        - ASTROPY_VERSION=2
+        - ASTROPY_VERSION=3
         - MAIN_CMD='python setup.py'
         # These packages will always be installed.
         - CONDA_DEPENDENCIES=''

--- a/py/specter/extract/ex2d.py
+++ b/py/specter/extract/ex2d.py
@@ -408,7 +408,7 @@ def ex2d_patch(image, ivar, psf, specmin, nspec, wavelengths, xyrange=None,
         print("ERROR: Linear Algebra didn't converge")
         print("Dumping {} for debugging".format(outfile))
         from astropy.io import fits
-        fits.writeto(outfile, image, clobber=True)
+        fits.writeto(outfile, image, overwrite=True)
         fits.append(outfile, ivar, name='IVAR')
         fits.append(outfile, A.data, name='ADATA')
         fits.append(outfile, A.indices, name='AINDICES')

--- a/py/specter/io.py
+++ b/py/specter/io.py
@@ -67,7 +67,7 @@ def write_spectra(outfile, wave, flux, ivar, resolution, header):
     hx.append(fits.ImageHDU(ivar.astype(np.float32), name='IVAR'))
     hx.append(fits.ImageHDU(wave.astype(np.float32), name='WAVELENGTH'))
     hx.append(fits.ImageHDU(resolution.astype(np.float32), name='RESOLUTION'))
-    hx.writeto(outfile, clobber=True)
+    hx.writeto(outfile, overwrite=True)
 
 
 def read_simspec(filename):

--- a/py/specter/test/squeeze_spot_psf.py
+++ b/py/specter/test/squeeze_spot_psf.py
@@ -28,7 +28,7 @@ spotpos, sposhdr    = fx[7].data, fx[7].header
 spotwave, swavehdr  = fx[8].data, fx[8].header
 throughput, thruhdr = fx[9].data, fx[9].header
 
-fits.writeto(outfile, x[:, 0::10], header=xhdr, clobber=True)
+fits.writeto(outfile, x[:, 0::10], header=xhdr, overwrite=True)
 fits.append(outfile, y[:, 0::10], header=yhdr)
 fits.append(outfile, w[:, 0::10], header=whdr)
 

--- a/py/specter/test/write_input_spectra.py
+++ b/py/specter/test/write_input_spectra.py
@@ -54,7 +54,7 @@ def write_imgspec(flux, wave, loglam, objtype):
         hdr['OBJTYPE'] = objtype
     
     filename = get_next_filename()
-    fits.writeto(filename, flux, header=hdr, clobber=True)
+    fits.writeto(filename, flux, header=hdr, overwrite=True)
     if wave is not None:
         if loglam:
             fits.append(filename, wave, extname='LOGLAM')
@@ -93,7 +93,7 @@ def write_tblspec(flux, wave, loglam, objtype):
         data['objtype'] = objtype['OBJTYPE']
     
     filename = get_next_filename()
-    fits.writeto(filename, data, header=hdr, clobber=True)
+    fits.writeto(filename, data, header=hdr, overwrite=True)
 
     return filename
 


### PR DESCRIPTION
This PR adds a reproducibility unit test that I was using to debug non-reproducibility at a certain computing center on Monday (i.e. it was failing), but subsequently something else changed and now I can't get the tests to fail anymore.  Either way, it seems useful to add these tests in case the problem crops up again.

While I'm at it, I changed `astropy.io.fits.write(clobber...)` to `overwrite` due to a deprecation warning (deprecated since astropy 2 and we're moving on to astropy 4 by now...)

I'm also updating the Travis testing to astropy 3, with the intension of letting Travis test backwards compatibility with astropy 3, while letting nightly tests at NERSC test astropy 4 (I don't want to bog down travis testing with multiple combinations of astropy, but we could consider it).