### PR TITLE
tune extraction padding parameters to minimize ringing

### DIFF
--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -6,6 +6,9 @@ specter change log
 ------------------
 
 * Replace biasing test >0 by !=0 in psf.project
+* Tune extraction patch boundary parameters to limit edge effects (PR `#82`_).
+
+.. _`#82`: https://github.com/desihub/specter/pull/82
 
 0.9.4 (2020-08-03)
 ------------------

--- a/py/specter/extract/ex2d.py
+++ b/py/specter/extract/ex2d.py
@@ -148,8 +148,8 @@ def ex2d(image, imageivar, psf, specmin, nspec, wavelengths, xyrange=None,
 
                 #- Extend pix range by another PSF width to reduce edge-effects
                 extra_ypix = int(round(pixpad_frac * spotsize[0]))
-                ylo -= extra_ypix
-                yhi += extra_ypix
+                ylo = max(0, ylo-extra_ypix)
+                yhi = min(psf.npix_y, yhi+extra_ypix)
 
                 if xyrange is None:
                     subxy = np.s_[ylo:yhi, xlo:xhi]

--- a/py/specter/extract/ex2d.py
+++ b/py/specter/extract/ex2d.py
@@ -179,11 +179,6 @@ def ex2d(image, imageivar, psf, specmin, nspec, wavelengths, xyrange=None,
                 wmin, wmax = ww[0], ww[-1]
                 nw = len(ww)
 
-                # print('--> {} {} {:.1f} {:.1f} {:.1f} {:.1f}  {}  {}'.format(
-                #     nlo, nhi, wmin, wlo, whi, wmax,
-                #     specrange,
-                #     (xlo,xhi,ylo,yhi)))
-
                 #- include \r carriage return to prevent scrolling
                 if verbose:
                     sys.stdout.write("\rSpectra {specrange} wavelengths ({wmin:.2f}, {wmax:.2f}) -> ({wlo:.2f}, {whi:.2f})".format(\

--- a/py/specter/extract/ex2d.py
+++ b/py/specter/extract/ex2d.py
@@ -18,7 +18,9 @@ from specter.util import outer
 def ex2d(image, imageivar, psf, specmin, nspec, wavelengths, xyrange=None,
          regularize=0.0, ndecorr=False, bundlesize=25, nsubbundles=1,
          wavesize=50, full_output=False, verbose=False,
-         debug=False, psferr=None):
+         debug=False, psferr=None,
+         pixpad_frac=0.8, wavepad_frac=0.2,
+         ):
     '''2D PSF extraction of flux from image patch given pixel inverse variance.
 
     Parameters
@@ -62,6 +64,10 @@ def ex2d(image, imageivar, psf, specmin, nspec, wavelengths, xyrange=None,
         fractional error on the psf model instead of the value saved
         in the psf fits file. This is used only to compute the chi2,
         not to weight pixels in fit
+    pixpad_frac : float, optional
+        fraction of a PSF spotsize to pad in pixels when extracting
+    wavepad_frac : float, optional
+        fraction of a PSF spotsize to pad in wavelengths when extracting
 
     Returns
     -------
@@ -132,13 +138,18 @@ def ex2d(image, imageivar, psf, specmin, nspec, wavelengths, xyrange=None,
             for iwave in range(0, len(wavelengths), wavesize):
                 #- Low and High wavelengths for the core region
                 wlo = wavelengths[iwave]
-                if iwave+wavesize < len(wavelengths):
-                    whi = wavelengths[iwave+wavesize]
+                if iwave+wavesize-1 < len(wavelengths):
+                    whi = wavelengths[iwave+wavesize-1]
                 else:
                     whi = wavelengths[-1]
 
                 #- Identify subimage that covers the core wavelengths
-                subxyrange = xlo,xhi,ylo,yhi = psf.xyrange(specrange, (wlo, whi))
+                xlo,xhi,ylo,yhi = psf.xyrange(specrange, (wlo, whi))
+
+                #- Extend pix range by another PSF width to reduce edge-effects
+                extra_ypix = int(round(pixpad_frac * spotsize[0]))
+                ylo -= extra_ypix
+                yhi += extra_ypix
 
                 if xyrange is None:
                     subxy = np.s_[ylo:yhi, xlo:xhi]
@@ -149,15 +160,23 @@ def ex2d(image, imageivar, psf, specmin, nspec, wavelengths, xyrange=None,
                 subivar = imageivar[subxy]
 
                 #- Determine extra border wavelength extent: nlo,nhi extra wavelength bins
-                ny, nx = psf.pix(speclo, wlo).shape
-                ymin = ylo-ny+2
-                ymax = yhi+ny-2
-
+                # ny, nx = psf.pix(speclo, wlo).shape
+                # ymin = ylo-ny+2
+                # ymax = yhi+ny-2
+                ny, nx = spotsize
+                ymin = ylo-int(wavepad_frac * ny)
+                ymax = yhi+int(wavepad_frac * ny)
                 nlo = max(int((wlo - psf.wavelength(speclo, ymin))/dw)-1, ndiag)
                 nhi = max(int((psf.wavelength(speclo, ymax) - whi)/dw)-1, ndiag)
+
                 ww = np.arange(wlo-nlo*dw, whi+(nhi+0.5)*dw, dw)
                 wmin, wmax = ww[0], ww[-1]
                 nw = len(ww)
+
+                # print('--> {} {} {:.1f} {:.1f} {:.1f} {:.1f}  {}  {}'.format(
+                #     nlo, nhi, wmin, wlo, whi, wmax,
+                #     specrange,
+                #     (xlo,xhi,ylo,yhi)))
 
                 #- include \r carriage return to prevent scrolling
                 if verbose:
@@ -191,8 +210,8 @@ def ex2d(image, imageivar, psf, specmin, nspec, wavelengths, xyrange=None,
                 #- Fill in the final output arrays
                 ## iispec = slice(speclo-specmin, spechi-specmin)
                 iispec = np.arange(speclo-specmin, spechi-specmin)
-                flux[iispec[keep], iwave:iwave+wavesize+1] = specflux[keep, nlo:-nhi]
-                ivar[iispec[keep], iwave:iwave+wavesize+1] = specivar[keep, nlo:-nhi]
+                flux[iispec[keep], iwave:iwave+wavesize] = specflux[keep, nlo:-nhi]
+                ivar[iispec[keep], iwave:iwave+wavesize] = specivar[keep, nlo:-nhi]
 
                 if full_output:
                     A = results['A'].copy()
@@ -236,8 +255,8 @@ def ex2d(image, imageivar, psf, specmin, nspec, wavelengths, xyrange=None,
                     #- outputs
                     #- TODO: watch out for edge effects on overlapping regions of submodels
                     modelimage[subxy] = submodel
-                    pixmask_fraction[iispec[keep], iwave:iwave+wavesize+1] = subpixmask_fraction[keep, nlo:-nhi]
-                    chi2pix[iispec[keep], iwave:iwave+wavesize+1] = chi2x[keep, nlo:-nhi]
+                    pixmask_fraction[iispec[keep], iwave:iwave+wavesize] = subpixmask_fraction[keep, nlo:-nhi]
+                    chi2pix[iispec[keep], iwave:iwave+wavesize] = chi2x[keep, nlo:-nhi]
 
                 #- Fill diagonals of resolution matrix
                 for ispec in np.arange(speclo, spechi)[keep]:

--- a/py/specter/extract/ex2d.py
+++ b/py/specter/extract/ex2d.py
@@ -148,8 +148,14 @@ def ex2d(image, imageivar, psf, specmin, nspec, wavelengths, xyrange=None,
 
                 #- Extend pix range by another PSF width to reduce edge-effects
                 extra_ypix = int(round(pixpad_frac * spotsize[0]))
-                ylo = max(0, ylo-extra_ypix)
-                yhi = min(psf.npix_y, yhi+extra_ypix)
+                ylo -= extra_ypix
+                yhi += extra_ypix
+                if xyrange is not None:
+                    ylo = max(ylo, xyrange[2])
+                    yhi = min(yhi, xyrange[3])
+                else:
+                    ylo = max(ylo, 0)
+                    yhi = min(yhi, psf.npix_y)
 
                 if xyrange is None:
                     subxy = np.s_[ylo:yhi, xlo:xhi]

--- a/py/specter/psf/psf.py
+++ b/py/specter/psf/psf.py
@@ -327,8 +327,8 @@ class PSF(object):
             wavemax = self.wmax
 
         #- Find the spectra with the smallest/largest y centroids
-        ispec_ymin = specmin + np.argmin(self.y(None, wavemin)[specmin:specmax+1])
-        ispec_ymax = specmin + np.argmax(self.y(None, wavemax)[specmin:specmax+1])
+        ispec_ymin = specmin + np.argmin(self.y(None, wavemin)[specmin:specmax])
+        ispec_ymax = specmin + np.argmax(self.y(None, wavemax)[specmin:specmax])
         ymin = self.xypix(ispec_ymin, wavemin)[1].start
         ymax = self.xypix(ispec_ymax, wavemax)[1].stop
 


### PR DESCRIPTION
This PR adjusts the boundary pixels and wavelengths used in the overlapping extraction patches, following the optimization study in DESI-6081 presented at the 2021-01-19 DESI Data telecon.  This minimizes residuals at the patch boundaries.  In particular, it fixes the divot at 9477 Angstroms reported in desihub/desispec#1101:
![image](https://user-images.githubusercontent.com/218471/107892360-6b2cf880-6ed9-11eb-8c86-482cf5bfc6f0.png)

This also fixes some off-by-one indexing bugs discovered while debugging this.

I'd like to include this with the cascades run so I plan self-merge.  Tests pass locally and this branch was additionally tested with real data to make the above plot; I may or may not wait for Travis tests.