### PR TITLE
avoid at-edge-of-ccd extraction crash

### DIFF
--- a/py/specter/psf/psf.py
+++ b/py/specter/psf/psf.py
@@ -375,7 +375,9 @@ class PSF(object):
             xmax = self.npix_x
         else:
             wxmax = w[np.argmax(x)]
-            xmax = self.xypix(specmax-1, wxmax)[0].stop
+            #- use _xypix not xypix to avoid corner-case rounding when
+            #- very near edge of CCD
+            xmax = self._xypix(specmax-1, wxmax)[0].stop
 
         return (xmin, xmax, ymin, ymax)
 

--- a/py/specter/test/test_psf.py
+++ b/py/specter/test/test_psf.py
@@ -340,6 +340,13 @@ class GenericPSFTests(object):
             self.assertTrue(xmin <= xmax)
             self.assertTrue(ymin <= ymax)
 
+        #- corner case that can fail with full PSFs even if they don't fail with
+        #- test PSFs, but add here anyway as an extra check
+        w_edge = psf.wavelength(psf.nspec-1, psf.npix_y-0.49999)
+        xmin, xmax, ymin, ymax = psf.xyrange(psf.nspec-1, [w_edge-1, w_edge])
+        self.assertGreater(xmax, xmin)
+        self.assertGreater(ymax, ymin)
+
     #- Test projection matrix with scalar vs. tuple spec_range
     def test_projmat_ispec(self):
         ispec = 0


### PR DESCRIPTION
This PR fixes desihub/desispec#1790 with an extremely corner case extraction bug.  If the wavelength solution had been 0.0001 Angstrom different in either direction it would not have crashed.  The underlying problem comes from the logic handling whether the requested spot is on, off, or partially on the CCD, and rounding differences in the round trip y -> wavelength -> y .  The solution in `psf.xyrange` was to use `psf._xypix` instead of `psf.xypix` to avoid one extra level of "am I on the edge of the CCD?" check.

I tried to add a unit test to catch this, but the trimmed down PSFs in the test suite aren't sensitive to this exact problem so they passed anyway even without the fix.  None-the-less, the additional test code does fail with the full PSF from himalayas/exposures/20220221/00123283/psf-z0-00123283.fits if not using the fix in this branch.  Having added the test, I left it in there anyway as some partial future insurance against a new bug.

Code to reproduce original failure without requiring full MPI and desi_proc like original report:
```
cd $CFS/desi/spectro/redux/himalayas
desi_extract_spectra -w 7520.0,9824.0,0.8 --psferr 0.1 --barycentric-correction \
    --nsubbundles 5 --specmin 475 --nspec 25 \
    -i preproc/20220221/00123283/preproc-z0-00123283.fits.gz \
    -p exposures/20220221/00123283/psf-z0-00123283.fits \
    -o $SCRATCH/frame-z0-00123283-no-badcolumn-mask.fits.gz
```
That fails with specter/main but passes with this branch.