### PR TITLE
overwrite not clobber for astropy >= 5.1

### DIFF
--- a/bin/specter
+++ b/bin/specter
@@ -422,7 +422,7 @@ if opts.extra:
                        ])
     hx.append(fits.BinTableHDU(a, header=hdr, name='XYWAVE'))
 
-hx.writeto(opts.output, clobber=True)
+hx.writeto(opts.output, overwrite=True)
 
 if opts.debug:
     #--- DEBUG ---


### PR DESCRIPTION
This PR fixes #85 ("overwrite" vs. "clobber"; astropy >= 5.1 now only supports "overwrite").

There was only one case of using "clobber" in specter; changing that to "overwrite" allows tests to pass again.  I've tested this with @marcelo-alvarez's desiconda environment with astropy 5.2 at
```
source /global/common/software/desi/users/malvarez/desi_environment.sh local 2.0.1
```

I plan to self merge.

Note: it appears that specter doesn't have travis, circleci, or github actions unit tests anymore, but I am not trying to fix that in this PR.  I have run the unit tests at NERSC.
